### PR TITLE
Remove duplicate iPad7,3 case

### DIFF
--- a/Classes/Utility/UIDevice+Model.swift
+++ b/Classes/Utility/UIDevice+Model.swift
@@ -47,7 +47,7 @@ extension UIDevice {
         case "iPad4,4", "iPad4,5", "iPad4,6":           return "iPad Mini 2"
         case "iPad4,7", "iPad4,8", "iPad4,9":           return "iPad Mini 3"
         case "iPad5,1", "iPad5,2":                      return "iPad Mini 4"
-        case "iPad6,3", "iPad6,4", "iPad6,7", "iPad6,8", "iPad7,1", "iPad7,2", " iPad7,3 ", " iPad7,3 ":                      return "iPad Pro"
+        case "iPad6,3", "iPad6,4", "iPad6,7", "iPad6,8", "iPad7,1", "iPad7,2", " iPad7,3 ":                      return "iPad Pro"
         case "AppleTV5,3":                              return "Apple TV"
         case "i386", "x86_64":                          return "Simulator"
         default:                                        return identifier


### PR DESCRIPTION
This was caught by static analysis in Xcode 9.3, cool 😎