### PR TITLE
Enable view source to open in GitHawk

### DIFF
--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -91,26 +91,20 @@ NewIssueTableViewControllerDelegate {
     // MARK: UITableViewDelegate
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        func deselectRow() { tableView.deselectRow(at: indexPath, animated: trueUnlessReduceMotionEnabled) }
+        tableView.deselectRow(at: indexPath, animated: trueUnlessReduceMotionEnabled)
         let cell = tableView.cellForRow(at: indexPath)
 
         if cell === reviewAccessCell {
-            deselectRow()
             onReviewAccess()
         } else if cell === accountsCell {
-            deselectRow()
             onAccounts()
         } else if cell === githubStatusCell {
-            deselectRow()
             onGitHubStatus()
         } else if cell === reportBugCell {
-            deselectRow()
             onReportBug()
         } else if cell === viewSourceCell {
-            deselectRow()
             onViewSource()
         } else if cell === signOutCell {
-            deselectRow()
             onSignOut()
         }
     }

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -107,6 +107,7 @@ NewIssueTableViewControllerDelegate {
             deselectRow()
             onReportBug()
         } else if cell === viewSourceCell {
+            deselectRow()
             onViewSource()
         } else if cell === signOutCell {
             deselectRow()
@@ -157,9 +158,19 @@ NewIssueTableViewControllerDelegate {
     }
 
     func onViewSource() {
-        guard let url = URL(string: Constants.URLs.repository)
-            else { fatalError("Should always create GitHub URL") }
-		presentSafari(url: url)
+        guard let client = client else {
+            ToastManager.showGenericError()
+            return
+        }
+
+        let repo = RepositoryDetails(
+            owner: "GitHawkApp",
+            name: "GitHawk",
+            defaultBranch: "master",
+            hasIssuesEnabled: true
+        )
+        let repoViewController = RepositoryViewController(client: client, repo: repo)
+        navigationController?.showDetailViewController(repoViewController, sender: self)
     }
 
     func onSignOut() {

--- a/Classes/Views/Constants.swift
+++ b/Classes/Views/Constants.swift
@@ -11,7 +11,6 @@ import Foundation
 enum Constants {
 
     enum URLs {
-        static let repository = "https://github.com/GitHawkApp/GitHawk/"
         static let website = "http://www.githawk.com/"
         static let blog = "http://blog.githawk.com/"
     }


### PR DESCRIPTION
Fixes #1629 

- Changes the `"View Source Code"` action to open the GitHawk in GitHawk vs SafariVC
- Removed `URLs.repository` constant from `Constants` as it's no longer being used
- **Note:** This will no longer work if the repo or owner name change
  - However, the same issue would happen with the url approach too.

## GIFS

### Success
<img src="https://user-images.githubusercontent.com/3321592/38217733-5eeaeff4-369d-11e8-8638-f2981b1e8c2c.gif" width=60% height=60%>

### Error
<img src="https://user-images.githubusercontent.com/3321592/38217728-5ebe350e-369d-11e8-8ebd-524ccf4b3438.gif" width=60% height=60%>

## iPad Screenshots
<img src="https://user-images.githubusercontent.com/3321592/38217730-5ed6e766-369d-11e8-810e-a7600fe3f536.png" width=80% height=80%>
<img src="https://user-images.githubusercontent.com/3321592/38217900-eece7492-369d-11e8-8044-f77e91af4856.png" width=80% height=80%>

