### PR TITLE
Updated the IssuesViewController to handle a target branch model

### DIFF
--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -457,6 +457,7 @@ final class IssuesViewController:
         case is IssueFileChangesModel: return IssueViewFilesSectionController(issueModel: model, client: client)
         case is IssueManagingModel: return IssueManagingSectionController(model: model, client: client)
         case is IssueMergeModel: return IssueMergeSectionController(model: model, client: client, resultID: resultID)
+        case is IssueTargetBranchModel: return IssueTargetBranchSectionController()
         default: fatalError("Unhandled object: \(object)")
         }
     }


### PR DESCRIPTION
The application crashes with `fatalError` when the user opens a pull request screen. The reason is that the `IssueTargetBranchModel` object is created by `GithubClient`, but not handled in the `IssuesViewController`. Introduced required updates. 