### PR TITLE
File name in comments not matching real file name

### DIFF
--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -1,5 +1,5 @@
 //
-//  SettingsViewController2.swift
+//  SettingsViewController.swift
 //  Freetime
 //
 //  Created by Ryan Nystrom on 7/31/17.


### PR DESCRIPTION
It was created as SettingsViewController2, but now it is called SettingsViewController.