### PR TITLE
updates add reviewers url path

### DIFF
--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 		98F9F4011F9CCFFE005A0266 /* ImgurClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F9F3FE1F9CCFFE005A0266 /* ImgurClient.swift */; };
 		98F9F4031F9CD006005A0266 /* Image+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F9F4021F9CD006005A0266 /* Image+Base64.swift */; };
 		BD3761B0209E032500401DFB /* BookmarkNavigationItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD3761AF209E032500401DFB /* BookmarkNavigationItemTests.swift */; };
+		BD89007E20B8844B0026013F /* NetworkingURLPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD89007D20B8844B0026013F /* NetworkingURLPathTests.swift */; };
 		D8BAD0601FDA0A1A00C41071 /* LabelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BAD05F1FDA0A1A00C41071 /* LabelListCell.swift */; };
 		D8BAD0641FDF221900C41071 /* LabelListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BAD0631FDF221900C41071 /* LabelListView.swift */; };
 		D8BAD0661FDF224600C41071 /* WrappingStaticSpacingFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BAD0651FDF224600C41071 /* WrappingStaticSpacingFlowLayout.swift */; };
@@ -927,6 +928,7 @@
 		ACAE4A11E9671879046F0CE7 /* Pods-FreetimeWatch.testflight.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FreetimeWatch.testflight.xcconfig"; path = "Pods/Target Support Files/Pods-FreetimeWatch/Pods-FreetimeWatch.testflight.xcconfig"; sourceTree = "<group>"; };
 		B3C439BE890EECD7C0C692C5 /* Pods-Freetime.testflight.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Freetime.testflight.xcconfig"; path = "Pods/Target Support Files/Pods-Freetime/Pods-Freetime.testflight.xcconfig"; sourceTree = "<group>"; };
 		BD3761AF209E032500401DFB /* BookmarkNavigationItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkNavigationItemTests.swift; sourceTree = "<group>"; };
+		BD89007D20B8844B0026013F /* NetworkingURLPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingURLPathTests.swift; sourceTree = "<group>"; };
 		D396E0DA66FED629384A84BC /* Pods_FreetimeWatch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FreetimeWatch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8BAD05F1FDA0A1A00C41071 /* LabelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelListCell.swift; sourceTree = "<group>"; };
 		D8BAD0631FDF221900C41071 /* LabelListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LabelListView.swift; sourceTree = "<group>"; };
@@ -1485,6 +1487,7 @@
 				29A476B11ED24D99005D0953 /* IssueTests.swift */,
 				29C2950D1EC7B43B00D46CD2 /* ListKitTestCase.swift */,
 				29C295091EC7AFA500D46CD2 /* ListTestKit.swift */,
+				BD89007D20B8844B0026013F /* NetworkingURLPathTests.swift */,
 				49AF91B0204B416500DFF325 /* MergeTests.swift */,
 				DC60C6CC1F98344B00241271 /* Mocks */,
 				49D028FF1F91D90C00E39094 /* ReactionTests.swift */,
@@ -3054,6 +3057,7 @@
 				DC60C6CE1F98346400241271 /* MockSearchEmptyViewDelegate.swift in Sources */,
 				DC60C6CB1F98341900241271 /* SearchEmptyViewTests.swift in Sources */,
 				293A45771F296B7E00DD1006 /* ListKitTestCase.swift in Sources */,
+				BD89007E20B8844B0026013F /* NetworkingURLPathTests.swift in Sources */,
 				BD3761B0209E032500401DFB /* BookmarkNavigationItemTests.swift in Sources */,
 				DC5C02C51F9C6E3500E80B9F /* SearchQueryTests.swift in Sources */,
 				293A457E1F296BD500DD1006 /* API.swift in Sources */,

--- a/FreetimeTests/NetworkingURLPathTests.swift
+++ b/FreetimeTests/NetworkingURLPathTests.swift
@@ -1,0 +1,82 @@
+//
+//  NetworkingURLPathTests.swift
+//  FreetimeTests
+//
+//  Created by B_Litwin on 5/25/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import GitHubAPI
+import XCTest
+@testable import Freetime
+
+class UrlPathComponents: XCTestCase {
+    
+    func test_addReviewers() {
+        
+        //test that add reviewers request gets a 401 unauthorized response instead of a 404
+        //Issue #1829: add reviewers was receiving a 404 response
+        let addReviewersRequest = V3AddPeopleRequest(owner: "GitHawkApp",
+                                                     repo: "GitHawk",
+                                                     number: 1549,
+                                                     type: .reviewers,
+                                                     add: true,
+                                                     people: [])
+        
+        let githubclient = newGithubClient()
+        let promise = expectation(description: "completion handler invoked")
+        var requestResponse: GitHubAPI.Result<V3StatusCodeResponse<V3StatusCode200or201>>?
+        
+        githubclient.client.send(addReviewersRequest) { response in
+            requestResponse = response
+            promise.fulfill()
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
+        
+        switch requestResponse! {
+        case .failure(let error):
+            let clientError = error as! GitHubAPI.ClientError
+            switch clientError {
+            case .unauthorized: break //test passed i.e. received a 401 response
+            default: XCTFail("Client Error hould be .unauthorized i.e. 401 response")
+            }
+        default:
+            XCTFail("Response should be ResponseType.failure(GitHubAPI.ClientError.unauthorized) i.e. 401 response")
+        }
+    }
+    
+    func test_addAssignees() {
+        
+        //test that add reviewers request gets a 401 unauthorized response
+        let addAssigneesRequest = V3AddPeopleRequest(owner: "GitHawkApp",
+                                                     repo: "GitHawk",
+                                                     number: 1549,
+                                                     type: .assignees,
+                                                     add: true,
+                                                     people: [])
+        
+        let githubclient = newGithubClient()
+        let promise = expectation(description: "completion handler invoked")
+        var requestResponse: GitHubAPI.Result<V3StatusCodeResponse<V3StatusCode200or201>>?
+        
+        githubclient.client.send(addAssigneesRequest) { response in
+            requestResponse = response
+            promise.fulfill()
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
+        
+        switch requestResponse! {
+        case .failure(let error):
+            let clientError = error as! GitHubAPI.ClientError
+            switch clientError {
+            case .unauthorized: break //test passed i.e. received a 401 response
+            default: XCTFail("Client Error should be .unauthorized i.e. 401 response")
+            }
+        default:
+            XCTFail("Response should be ResponseType.failure(GitHubAPI.ClientError.unauthorized) i.e. 401 response")
+        }
+    }
+}
+

--- a/Local Pods/GitHubAPI/GitHubAPI/V3AddPeopleRequest.swift
+++ b/Local Pods/GitHubAPI/GitHubAPI/V3AddPeopleRequest.swift
@@ -18,11 +18,14 @@ public struct V3AddPeopleRequest: V3Request {
     public typealias ResponseType = V3StatusCodeResponse<V3StatusCode200or201>
     public var pathComponents: [String] {
         let last: String
+        let fourth: String
         switch type {
         case .assignees: last = "assignees"
+            fourth = "issues"
         case .reviewers: last = "requested_reviewers"
+            fourth = "pulls"
         }
-        return ["repos", owner, repo, "issues", "\(number)", last]
+        return ["repos", owner, repo, fourth, "\(number)", last]
     }
     public var parameters: [String : Any]? {
         let key: String


### PR DESCRIPTION
Changed the path component for adding reviewers. Hopefully resolves #1829.  I'm basing the change off the API docs and the unit tests.. I'm not sure how to reproduce this issue manually in the app. 

Also, the unit tests use GithubClient to send the requests as opposed to a URLSession.. the downside being that a failed test doesn't give you much info other than "not a ClientError.unauthorized i.e. 401 response". If it would be preferable to use a URLSession that gives a regular status code to test against, let me know and I'll swap them out.  