### PR TITLE
Do not allow review request from PR author

### DIFF
--- a/Classes/Issues/Managing/IssueManagingSectionController.swift
+++ b/Classes/Issues/Managing/IssueManagingSectionController.swift
@@ -109,12 +109,24 @@ ContextMenuDelegate {
 
     func newPeopleController(type: PeopleViewController.PeopleType) -> UIViewController {
         let selections: [String]
+        let exclusions: [String]
         switch type {
-        case .assignee: selections = issueResult?.assignee.users.map { $0.login } ?? []
-        case .reviewer: selections = issueResult?.reviewers?.users.map { $0.login } ?? []
+        case .assignee:
+            selections = issueResult?.assignee.users.map { $0.login } ?? []
+            exclusions = []
+        case .reviewer:
+            selections = issueResult?.reviewers?.users.map { $0.login } ?? []
+            if let isPullRequest = issueResult?.pullRequest,
+                let pullRequestAuthor = issueResult?.rootComment?.details.login,
+                isPullRequest {
+                exclusions = [pullRequestAuthor]
+            } else {
+                exclusions = []
+            }
         }
         return PeopleViewController(
             selections: selections,
+            exclusions: exclusions,
             type: type,
             client: client,
             owner: model.owner,

--- a/Classes/People/PeopleViewController.swift
+++ b/Classes/People/PeopleViewController.swift
@@ -23,6 +23,7 @@ PeopleSectionControllerDelegate {
 
     private let selections: Set<String>
     private let selectionLimit = 10
+    private let exclusions: Set<String>
     private var users = [IssueAssigneeViewModel]()
     private let client: GithubClient
     private var owner: String
@@ -30,12 +31,14 @@ PeopleSectionControllerDelegate {
 
     init(
         selections: [String],
+        exclusions: [String],
         type: PeopleType,
         client: GithubClient,
         owner: String,
         repo: String
         ) {
         self.selections = Set<String>(selections)
+        self.exclusions = Set<String>(exclusions)
         self.type = type
         self.client = client
         self.owner = owner
@@ -121,13 +124,15 @@ PeopleSectionControllerDelegate {
     // MARK: BaseListViewController2DataSource
 
     func models(adapter: ListSwiftAdapter) -> [ListSwiftPair] {
-        return users.map { [selections] user in
-            return ListSwiftPair.pair(user) { [weak self] in
-                let controller = PeopleSectionController(selected: selections.contains(user.login))
-                controller.delegate = self
-                return controller
+        return users
+            .filter { [exclusions] user in !exclusions.contains(user.login) }
+            .map { [selections] user in
+                return ListSwiftPair.pair(user) { [weak self] in
+                    let controller = PeopleSectionController(selected: selections.contains(user.login))
+                    controller.delegate = self
+                    return controller
+                }
             }
-        }
     }
 
     // MARK: PeopleSectionControllerDelegate


### PR DESCRIPTION
Fixes #1850

This pulls out the PR author from the `IssueResult` and filters out the author from the list of potential reviewers.

I was originally going to change `IssueResult` to include an author object but saw that the author is referred to using the root comment [here](https://github.com/GitHawkApp/GitHawk/blob/master/Classes/Issues/GithubClient+Issues.swift#L94-L101)