### PR TITLE
patches shortlink regex to include links inside parentheses

### DIFF
--- a/Classes/Issues/Comments/Markdown/String+DetectShortlink.swift
+++ b/Classes/Issues/Comments/Markdown/String+DetectShortlink.swift
@@ -16,7 +16,7 @@ extension NSRange {
     }
 }
 
-private let regex = try! NSRegularExpression(pattern: "(^|\\s)((\\w+)/(\\w+))?#([0-9]+)", options: [])
+private let regex = try! NSRegularExpression(pattern: "(^|\\s|\\()((\\w+)/(\\w+))?#([0-9]+)", options: [])
 extension String {
     func detectAndHandleShortlink(owner: String, repo: String, builder: StyledTextBuilder) {
         let matches = regex.matches(in: self, options: [], range: nsrange)


### PR DESCRIPTION
bare minimum patch to consider for #1957
added an alternative expression that matches an opening "("
