### PR TITLE
updates/tests shortlink string matching

### DIFF
--- a/Classes/Issues/Comments/Markdown/String+DetectShortlink.swift
+++ b/Classes/Issues/Comments/Markdown/String+DetectShortlink.swift
@@ -16,7 +16,7 @@ extension NSRange {
     }
 }
 
-private let regex = try! NSRegularExpression(pattern: "(^|\\s)((\\w+)/(\\w+))?#([0-9]+)", options: [])
+private let regex = try! NSRegularExpression(pattern: "(^|\\s)((\\w+)/(\\w+))?(#([0-9]+)|\\(#([0-9]+)\\))($|\\s)", options: [])
 extension String {
     func detectAndHandleShortlink(owner: String, repo: String, builder: StyledTextBuilder) {
         let matches = regex.matches(in: self, options: [], range: nsrange)

--- a/FreetimeTests/ShortlinkMatchTests.swift
+++ b/FreetimeTests/ShortlinkMatchTests.swift
@@ -1,0 +1,90 @@
+//
+//  ShortlinkMatchTests.swift
+//  FreetimeTests
+//
+//  Created by B_Litwin on 7/22/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import XCTest
+@testable import Freetime
+import StyledTextKit
+
+class ShortlinkRegExTests: XCTestCase {
+    // Test the String method detectAndHandleShortlink()
+
+    func setupBuilder(with text: String) -> StyledTextString {
+        let builder = StyledTextBuilder(text: "")
+        text.detectAndHandleShortlink(
+            owner: "rnystrom",
+            repo: "GitHawk",
+            builder: builder
+        )
+        return builder.build()
+    }
+    
+    func checkForIssueLink(_ styledTexts: [StyledText]) -> Bool {
+        // scanning for a styledText unit that has been formatted with blue font and
+        // contains an Issue MarkdownAttribute
+        for style in styledTexts.map({ $0.style }) {
+            guard style.attributes[.foregroundColor] != nil,
+                style.attributes[MarkdownAttribute.issue] != nil else { continue }
+            let correctTextColor = style.attributes[.foregroundColor] as! UIColor == Styles.Colors.Blue.medium.color
+            if correctTextColor { return true }
+        }
+        
+        return false
+    }
+    
+    func test_positiveMatches() {
+        var builder: StyledTextString = setupBuilder(with: "#1234")
+        var containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertTrue(containsLink)
+        
+        builder = setupBuilder(with: "with a space preceding #1234")
+        containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertTrue(containsLink)
+        
+        builder = setupBuilder(with: "with a newline preceding \n#1234")
+        containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertTrue(containsLink)
+        
+        builder = setupBuilder(with: "embedded in parentheses (#1234)")
+        containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertTrue(containsLink)
+        
+        builder = setupBuilder(with: "with owner and repo preceding rnystrom/githawk#1234")
+        containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertTrue(containsLink)
+    }
+    
+    func test_negativeMatches() {
+        var builder = setupBuilder(with: "!1234")
+        var containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertFalse(containsLink)
+        
+        builder = setupBuilder(with: "imo the best pr so far is prob # 1906")
+        containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertFalse(containsLink)
+        
+        builder = setupBuilder(with: "#123T")
+        containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertFalse(containsLink)
+        
+        builder = setupBuilder(with: "Fixes#1234")
+        containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertFalse(containsLink)
+        
+        builder = setupBuilder(with: "Fixes(#1234)")
+        containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertFalse(containsLink)
+        
+        builder = setupBuilder(with: "Fixes (#1234")
+        containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertFalse(containsLink)
+        
+        builder = setupBuilder(with: "Fixes #1234)")
+        containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertFalse(containsLink)
+    }
+}


### PR DESCRIPTION
re-did PR #1963 
- added unit tests 
- added a more specific RegEx clause to match issue numbers enclosed in parentheses 
- added a RegEx clause to catch invalid trailing characters. #1900W is considered a match in the current RegEx pattern. 

The RegEx is more long-winded than before but easy to test. 