### PR TITLE
Fixed preferredContentSizeCategory called on background thread issue

### DIFF
--- a/Classes/Bookmark/BookmarkViewController.swift
+++ b/Classes/Bookmark/BookmarkViewController.swift
@@ -155,7 +155,7 @@ TabNavRootViewControllerType {
     // MARK: ListAdapterDataSource
 
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
         let width = view.bounds.width
         var bookmarks: [ListDiffable]
         switch state {

--- a/Classes/Issues/Comments/IssueCommentSectionController.swift
+++ b/Classes/Issues/Comments/IssueCommentSectionController.swift
@@ -223,7 +223,7 @@ final class IssueCommentSectionController:
             repo: model.repo,
             width: width,
             viewerCanUpdate: true,
-            contentSizeCategory: UIApplication.shared.preferredContentSizeCategory,
+            contentSizeCategory: UIContentSizeCategory.preferred,
             isRoot: self.object?.isRoot == true
         )
         bodyEdits = (markdown, bodyModels)

--- a/Classes/Issues/Files/IssuePatchContentViewController.swift
+++ b/Classes/Issues/Files/IssuePatchContentViewController.swift
@@ -30,7 +30,7 @@ final class IssuePatchContentViewController: UIViewController {
         view.addSubview(codeView)
         codeView.set(
             attributedCode: CreateDiffString(code: patch)
-                .render(contentSizeCategory: UIApplication.shared.preferredContentSizeCategory)
+                .render(contentSizeCategory: UIContentSizeCategory.preferred)
         )
     }
 

--- a/Classes/Issues/GithubClient+Issues.swift
+++ b/Classes/Issues/GithubClient+Issues.swift
@@ -55,7 +55,7 @@ extension GithubClient {
         )
 
         let cache = self.cache
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
 
         client.query(query, result: { $0.repository }) { result in
             switch result {
@@ -351,7 +351,7 @@ extension GithubClient {
         ) {
         guard let actor = userSession?.username else { return }
 
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
         let oldLabelNames = Set<String>(previous.labels.labels.map { $0.name })
         let newLabelNames = Set<String>(labels.map { $0.name })
 
@@ -441,7 +441,7 @@ extension GithubClient {
         var newEvents = [IssueRequestModel]()
         var added = [String]()
         var removed = [String]()
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
 
         for old in oldAssigness {
             if !newAssignees.contains(old) {

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -523,7 +523,7 @@ final class IssuesViewController:
                 id: id,
                 commentFields: commentFields,
                 reactionFields: reactionFields,
-                contentSizeCategory: UIApplication.shared.preferredContentSizeCategory,
+                contentSizeCategory: UIContentSizeCategory.preferred,
                 width: view.bounds.width,
                 owner: model.owner,
                 repo: model.repo,

--- a/Classes/Issues/Preview/IssuePreviewViewController.swift
+++ b/Classes/Issues/Preview/IssuePreviewViewController.swift
@@ -44,7 +44,7 @@ final class IssuePreviewViewController: UIViewController, ListAdapterDataSource 
             repo: repo,
             width: view.bounds.width,
             viewerCanUpdate: false,
-            contentSizeCategory: UIApplication.shared.preferredContentSizeCategory,
+            contentSizeCategory: UIContentSizeCategory.preferred,
             isRoot: false
         )
         model = IssuePreviewModel(models: viewModels)

--- a/Classes/Milestones/GithubClient+Milestones.swift
+++ b/Classes/Milestones/GithubClient+Milestones.swift
@@ -75,7 +75,7 @@ extension GithubClient {
             milestone: eventTitle,
             date: Date(),
             type: type,
-            contentSizeCategory: UIApplication.shared.preferredContentSizeCategory,
+            contentSizeCategory: UIContentSizeCategory.preferred,
             width: 0 // pay perf cost when asked
         )
 

--- a/Classes/Notifications/NotificationModelController.swift
+++ b/Classes/Notifications/NotificationModelController.swift
@@ -51,7 +51,7 @@ final class NotificationModelController {
         width: CGFloat,
         completion: @escaping (Result<([NotificationViewModel], Int?)>) -> Void
         ) {
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
         // TODO move handling + parsing to a single method?
         if let repo = repo {
             githubClient.client.send(V3RepositoryNotificationRequest(all: all, owner: repo.owner, repo: repo.name)) { result in

--- a/Classes/PullRequestReviews/GithubClient+PullRequestReviewComments.swift
+++ b/Classes/PullRequestReviews/GithubClient+PullRequestReviewComments.swift
@@ -30,7 +30,7 @@ extension GithubClient {
         completion: @escaping (Result<[ListDiffable]>) -> ()
         ) {
         let viewerUsername = userSession?.username
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
 
         client.send(V3PullRequestCommentsRequest(owner: owner, repo: repo, number: number)) { result in
             switch result {
@@ -118,7 +118,7 @@ extension GithubClient {
         completion: @escaping (Result<IssueCommentModel>) -> ()
         ) {
         let viewer = userSession?.username
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
 
         client.send(V3SendPullRequestCommentRequest(
             owner: owner,

--- a/Classes/Repository/RepositoryClient.swift
+++ b/Classes/Repository/RepositoryClient.swift
@@ -127,7 +127,7 @@ final class RepositoryClient {
         containerWidth: CGFloat,
         completion: @escaping (Result<RepositoryPayload>) -> Void
     ) where T: RepositoryQuery {
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
         githubClient.client.query(query, result: { $0 }) { result in
             switch result {
             case .failure:

--- a/Classes/Repository/RepositoryOverviewViewController.swift
+++ b/Classes/Repository/RepositoryOverviewViewController.swift
@@ -42,7 +42,7 @@ BaseListViewControllerDataSource {
     override func fetch(page: NSString?) {
         let repo = self.repo
         let width = view.bounds.width
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
 
         client.githubClient.client
             .send(V3RepositoryReadmeRequest(owner: repo.owner, repo: repo.name)) { [weak self] result in

--- a/Classes/Systems/AppDelegate.swift
+++ b/Classes/Systems/AppDelegate.swift
@@ -71,6 +71,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // log device environment information
         LogEnvironmentInformation(application: application)
 
+        // setup content size category change handler
+        UIContentSizeCategoryChangeHandler.shared.setup()
+
         return true
     }
 

--- a/Classes/Systems/Autocomplete/AutocompleteCell.swift
+++ b/Classes/Systems/Autocomplete/AutocompleteCell.swift
@@ -97,7 +97,7 @@ final class AutocompleteCell: StyledTableCell {
         emojiLabel.isHidden = emojiHidden
         thumbnailImageView.isHidden = thumbnailHidden
         titleLabel.attributedText = builder.build()
-            .render(contentSizeCategory: UIApplication.shared.preferredContentSizeCategory)
+            .render(contentSizeCategory: UIContentSizeCategory.preferred)
 
         let left = emojiHidden && thumbnailHidden
             ? Styles.Sizes.gutter

--- a/Classes/Systems/ForegroundHandler.swift
+++ b/Classes/Systems/ForegroundHandler.swift
@@ -39,11 +39,11 @@ final class ForegroundHandler {
 
     // MARK: Private API
 
-    @objc func willResignActive() {
+    @objc private func willResignActive() {
         backgrounded = CACurrentMediaTime()
     }
 
-    @objc func didBecomeActive() {
+    @objc private func didBecomeActive() {
         guard let backgrounded = self.backgrounded else { return }
         self.backgrounded = nil
         if CACurrentMediaTime() - backgrounded > threshold {

--- a/Classes/Systems/UIContentSizeCategoryChangeHandler.swift
+++ b/Classes/Systems/UIContentSizeCategoryChangeHandler.swift
@@ -1,0 +1,34 @@
+//
+//  UIContentSizeCategoryChangeHandler.swift
+//  Freetime
+//
+//  Created by Ivan Smetanin on 08/04/2018.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import UIKit
+
+final class UIContentSizeCategoryChangeHandler {
+
+    public static let shared = UIContentSizeCategoryChangeHandler()
+
+    private init() {}
+
+    func setup() {
+        let center = NotificationCenter.default
+        center.addObserver(
+            self,
+            selector: #selector(contentSizeCategoryDidChange),
+            name: .UIContentSizeCategoryDidChange,
+            object: nil
+        )
+    }
+
+    // MARK: Private API
+
+    @objc private func contentSizeCategoryDidChange() {
+        print("change")
+        UIContentSizeCategory.preferred = UIContentSizeCategory.preferred
+    }
+
+}

--- a/Classes/Utility/UIContentSizeCategory+Preferred.swift
+++ b/Classes/Utility/UIContentSizeCategory+Preferred.swift
@@ -1,0 +1,15 @@
+//
+//  UIContentSizeCategory.swift
+//  Freetime
+//
+//  Created by Ivan Smetanin on 08/04/2018.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import UIKit
+
+extension UIContentSizeCategory {
+
+    static var preferred: UIContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+
+}

--- a/Classes/Views/Styles.swift
+++ b/Classes/Views/Styles.swift
@@ -134,7 +134,7 @@ enum Styles {
 extension TextStyle {
 
     var preferredFont: UIFont {
-        return self.font(contentSizeCategory: UIApplication.shared.preferredContentSizeCategory)
+        return self.font(contentSizeCategory: UIContentSizeCategory.preferred)
     }
 
     func with(attributes: [NSAttributedStringKey: Any]) -> TextStyle {

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -407,6 +407,8 @@
 		7BBFEE5B1F8A8A0400C68E47 /* SearchBarSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBFEE581F8A8A0400C68E47 /* SearchBarSectionController.swift */; };
 		7BF2239D1F91056C006CC9A2 /* File+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF2239C1F91056C006CC9A2 /* File+Filename.swift */; };
 		8960A556E8729CB4031DD641 /* Pods_FreetimeTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 516CF27F9258BBD3E034F09D /* Pods_FreetimeTests.framework */; };
+		8BBB3A9121158AED00B93335 /* UIContentSizeCategory+Preferred.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBB3A9021158AED00B93335 /* UIContentSizeCategory+Preferred.swift */; };
+		8BBB3A9321158B8500B93335 /* UIContentSizeCategoryChangeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBB3A9221158B8500B93335 /* UIContentSizeCategoryChangeHandler.swift */; };
 		98003D8D1FCAD7FC00755C17 /* LabelDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98003D8C1FCAD7FC00755C17 /* LabelDetails.swift */; };
 		98647DF31F758CCF00A4DE7A /* NewIssueTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98647DF21F758CCF00A4DE7A /* NewIssueTableViewController.swift */; };
 		986B87191F2B875800AAB55C /* GithubClient+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986B87181F2B875800AAB55C /* GithubClient+Search.swift */; };
@@ -931,6 +933,8 @@
 		7BBFEE561F8A8A0400C68E47 /* SearchBarCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchBarCell.swift; sourceTree = "<group>"; };
 		7BBFEE581F8A8A0400C68E47 /* SearchBarSectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchBarSectionController.swift; sourceTree = "<group>"; };
 		7BF2239C1F91056C006CC9A2 /* File+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "File+Filename.swift"; sourceTree = "<group>"; };
+		8BBB3A9021158AED00B93335 /* UIContentSizeCategory+Preferred.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIContentSizeCategory+Preferred.swift"; sourceTree = "<group>"; };
+		8BBB3A9221158B8500B93335 /* UIContentSizeCategoryChangeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIContentSizeCategoryChangeHandler.swift; sourceTree = "<group>"; };
 		98003D8C1FCAD7FC00755C17 /* LabelDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelDetails.swift; sourceTree = "<group>"; };
 		98647DF21F758CCF00A4DE7A /* NewIssueTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewIssueTableViewController.swift; sourceTree = "<group>"; };
 		986B87181F2B875800AAB55C /* GithubClient+Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GithubClient+Search.swift"; sourceTree = "<group>"; };
@@ -1657,6 +1661,7 @@
 				2971722A1F069E6B005E43AC /* SpinnerSectionController.swift */,
 				292D2F1620FA5CAD00099342 /* Squawk+GitHawk.swift */,
 				29CCB28A1FDDFFA200E23FA0 /* String+GithubDate.swift */,
+				8BBB3A9221158B8500B93335 /* UIContentSizeCategoryChangeHandler.swift */,
 				292CD3CF1F0DBB5C00D3D57B /* WebviewCellHeightCache.swift */,
 				2930F2721F8A27750082BA26 /* WidthCache.swift */,
 				D8BAD0651FDF224600C41071 /* WrappingStaticSpacingFlowLayout.swift */,
@@ -2049,6 +2054,7 @@
 				98835BCD1F1965E2005BA24F /* UIDevice+Model.swift */,
 				98B5A0851F6D0FFE000617D6 /* UINavigationController+Replace.swift */,
 				299F63DF205DDF6B0015D901 /* UIViewController+Routing.swift */,
+				8BBB3A9021158AED00B93335 /* UIContentSizeCategory+Preferred.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -3030,6 +3036,7 @@
 				2977788A20B306F200F2AFC2 /* LabelLayoutManager.swift in Sources */,
 				29DB264A1FCA10A800C3D0C9 /* GithubHighlighting.swift in Sources */,
 				2950AB1D2083B1E400C6F19A /* EmptyLoadingView.swift in Sources */,
+				8BBB3A9121158AED00B93335 /* UIContentSizeCategory+Preferred.swift in Sources */,
 				29B0EF871F93DF6C00870291 /* RepositoryCodeBlobViewController.swift in Sources */,
 				98F9F4001F9CCFFE005A0266 /* ImageUploadTableViewController.swift in Sources */,
 				29C167671ECA005500439D62 /* Constants.swift in Sources */,
@@ -3062,6 +3069,7 @@
 				292CD3D21F0DBEC000D3D57B /* UIViewController+Safari.swift in Sources */,
 				290D2A3D1F044CB20082E6CC /* UIViewController+SmartDeselection.swift in Sources */,
 				7BBFEE591F8A8A0400C68E47 /* SearchBarCell.swift in Sources */,
+				8BBB3A9321158B8500B93335 /* UIContentSizeCategoryChangeHandler.swift in Sources */,
 				4920F1A81F72E27200131E9D /* UIViewController+UserActivity.swift in Sources */,
 				2982ED7A1F94EA8F00DBF8EB /* UICollectionViewCell+SafeAreaContentView.swift in Sources */,
 				29351EA02079246400FF8C17 /* CodeBlockModel.swift in Sources */,


### PR DESCRIPTION
**Changes:**
- Added `static` property `preferred` to `UIContentSizeCategory` - now we can use this property instead of `UIApplication.shared.preferredContentSizeCategory`. These changes fix #1907 issue
- Added `UIContentSizeCategoryChangeHandler` to handle changing of preferredContentSizeCategory
- Changed access level from internal to private for methods in `ForegroundHandler`

**Steps to reproduce #1907**:
1. Open the app
2. Select the "Settings" tab
3. Select the "View Source Code" sell
4. ✅ You can see the "UI API called from background thread" in your Runtime errors

**Notes:**
I also found a bug on my iPhone 6S with iOS 11.4: when the application is running and I increase `Larger Text` in Settings/Accessibility, layout in the application goes wrong. I attached screenshots below.
We can fix it easily by removing `UIContentSizeCategoryChangeHandler`, but then a user will need to restart the application to see changed fonts. 

![group](https://user-images.githubusercontent.com/11653316/43674041-df202d08-97d5-11e8-8973-9c637a55ba17.png)