### PR TITLE
Fixed preferredContentSizeCategory called on background thread issue

### DIFF
--- a/Classes/Bookmark/BookmarkViewController.swift
+++ b/Classes/Bookmark/BookmarkViewController.swift
@@ -155,7 +155,7 @@ TabNavRootViewControllerType {
     // MARK: ListAdapterDataSource
 
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
         let width = view.bounds.width
         var bookmarks: [ListDiffable]
         switch state {

--- a/Classes/Issues/Comments/IssueCommentSectionController.swift
+++ b/Classes/Issues/Comments/IssueCommentSectionController.swift
@@ -223,7 +223,7 @@ final class IssueCommentSectionController:
             repo: model.repo,
             width: width,
             viewerCanUpdate: true,
-            contentSizeCategory: UIApplication.shared.preferredContentSizeCategory,
+            contentSizeCategory: UIContentSizeCategory.preferred,
             isRoot: self.object?.isRoot == true
         )
         bodyEdits = (markdown, bodyModels)

--- a/Classes/Issues/Files/IssuePatchContentViewController.swift
+++ b/Classes/Issues/Files/IssuePatchContentViewController.swift
@@ -30,7 +30,7 @@ final class IssuePatchContentViewController: UIViewController {
         view.addSubview(codeView)
         codeView.set(
             attributedCode: CreateDiffString(code: patch)
-                .render(contentSizeCategory: UIApplication.shared.preferredContentSizeCategory)
+                .render(contentSizeCategory: UIContentSizeCategory.preferred)
         )
     }
 

--- a/Classes/Issues/GithubClient+Issues.swift
+++ b/Classes/Issues/GithubClient+Issues.swift
@@ -55,7 +55,7 @@ extension GithubClient {
         )
 
         let cache = self.cache
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
 
         client.query(query, result: { $0.repository }) { result in
             switch result {
@@ -351,7 +351,7 @@ extension GithubClient {
         ) {
         guard let actor = userSession?.username else { return }
 
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
         let oldLabelNames = Set<String>(previous.labels.labels.map { $0.name })
         let newLabelNames = Set<String>(labels.map { $0.name })
 
@@ -441,7 +441,7 @@ extension GithubClient {
         var newEvents = [IssueRequestModel]()
         var added = [String]()
         var removed = [String]()
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
 
         for old in oldAssigness {
             if !newAssignees.contains(old) {

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -523,7 +523,7 @@ final class IssuesViewController:
                 id: id,
                 commentFields: commentFields,
                 reactionFields: reactionFields,
-                contentSizeCategory: UIApplication.shared.preferredContentSizeCategory,
+                contentSizeCategory: UIContentSizeCategory.preferred,
                 width: view.bounds.width,
                 owner: model.owner,
                 repo: model.repo,

--- a/Classes/Issues/Preview/IssuePreviewViewController.swift
+++ b/Classes/Issues/Preview/IssuePreviewViewController.swift
@@ -44,7 +44,7 @@ final class IssuePreviewViewController: UIViewController, ListAdapterDataSource 
             repo: repo,
             width: view.bounds.width,
             viewerCanUpdate: false,
-            contentSizeCategory: UIApplication.shared.preferredContentSizeCategory,
+            contentSizeCategory: UIContentSizeCategory.preferred,
             isRoot: false
         )
         model = IssuePreviewModel(models: viewModels)

--- a/Classes/Milestones/GithubClient+Milestones.swift
+++ b/Classes/Milestones/GithubClient+Milestones.swift
@@ -75,7 +75,7 @@ extension GithubClient {
             milestone: eventTitle,
             date: Date(),
             type: type,
-            contentSizeCategory: UIApplication.shared.preferredContentSizeCategory,
+            contentSizeCategory: UIContentSizeCategory.preferred,
             width: 0 // pay perf cost when asked
         )
 

--- a/Classes/Notifications/NotificationModelController.swift
+++ b/Classes/Notifications/NotificationModelController.swift
@@ -51,7 +51,7 @@ final class NotificationModelController {
         width: CGFloat,
         completion: @escaping (Result<([NotificationViewModel], Int?)>) -> Void
         ) {
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
         // TODO move handling + parsing to a single method?
         if let repo = repo {
             githubClient.client.send(V3RepositoryNotificationRequest(all: all, owner: repo.owner, repo: repo.name)) { result in

--- a/Classes/PullRequestReviews/GithubClient+PullRequestReviewComments.swift
+++ b/Classes/PullRequestReviews/GithubClient+PullRequestReviewComments.swift
@@ -30,7 +30,7 @@ extension GithubClient {
         completion: @escaping (Result<[ListDiffable]>) -> ()
         ) {
         let viewerUsername = userSession?.username
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
 
         client.send(V3PullRequestCommentsRequest(owner: owner, repo: repo, number: number)) { result in
             switch result {
@@ -118,7 +118,7 @@ extension GithubClient {
         completion: @escaping (Result<IssueCommentModel>) -> ()
         ) {
         let viewer = userSession?.username
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
 
         client.send(V3SendPullRequestCommentRequest(
             owner: owner,

--- a/Classes/Repository/RepositoryClient.swift
+++ b/Classes/Repository/RepositoryClient.swift
@@ -127,7 +127,7 @@ final class RepositoryClient {
         containerWidth: CGFloat,
         completion: @escaping (Result<RepositoryPayload>) -> Void
     ) where T: RepositoryQuery {
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
         githubClient.client.query(query, result: { $0 }) { result in
             switch result {
             case .failure:

--- a/Classes/Repository/RepositoryOverviewViewController.swift
+++ b/Classes/Repository/RepositoryOverviewViewController.swift
@@ -42,7 +42,7 @@ BaseListViewControllerDataSource {
     override func fetch(page: NSString?) {
         let repo = self.repo
         let width = view.bounds.width
-        let contentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        let contentSizeCategory = UIContentSizeCategory.preferred
 
         client.githubClient.client
             .send(V3RepositoryReadmeRequest(owner: repo.owner, repo: repo.name)) { [weak self] result in

--- a/Classes/Systems/Autocomplete/AutocompleteCell.swift
+++ b/Classes/Systems/Autocomplete/AutocompleteCell.swift
@@ -97,7 +97,7 @@ final class AutocompleteCell: StyledTableCell {
         emojiLabel.isHidden = emojiHidden
         thumbnailImageView.isHidden = thumbnailHidden
         titleLabel.attributedText = builder.build()
-            .render(contentSizeCategory: UIApplication.shared.preferredContentSizeCategory)
+            .render(contentSizeCategory: UIContentSizeCategory.preferred)
 
         let left = emojiHidden && thumbnailHidden
             ? Styles.Sizes.gutter

--- a/Classes/Utility/UIContentSizeCategory+Preferred.swift
+++ b/Classes/Utility/UIContentSizeCategory+Preferred.swift
@@ -1,0 +1,15 @@
+//
+//  UIContentSizeCategory+Preferred.swift
+//  Freetime
+//
+//  Created by Ivan Smetanin on 08/05/2018.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import UIKit
+
+extension UIContentSizeCategory {
+
+    static var preferred: UIContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+
+}

--- a/Classes/Views/Styles.swift
+++ b/Classes/Views/Styles.swift
@@ -134,7 +134,7 @@ enum Styles {
 extension TextStyle {
 
     var preferredFont: UIFont {
-        return self.font(contentSizeCategory: UIApplication.shared.preferredContentSizeCategory)
+        return self.font(contentSizeCategory: UIContentSizeCategory.preferred)
     }
 
     func with(attributes: [NSAttributedStringKey: Any]) -> TextStyle {


### PR DESCRIPTION
According to #2029

**Changes:**
- Added static property preferred to UIContentSizeCategory - now we can use this property instead of UIApplication.shared.preferredContentSizeCategory.