### PR TITLE
lines up contextMenu labels

### DIFF
--- a/Classes/View Controllers/ContrastContextMenu.swift
+++ b/Classes/View Controllers/ContrastContextMenu.swift
@@ -55,6 +55,16 @@ final class ContrastContextMenu: UITableViewController {
             border = contentView.addBorder(.top)
             border?.backgroundColor = Styles.Colors.Gray.medium.color
         }
+        
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            guard let frame = textLabel?.frame, imageView != nil else { return }
+            textLabel?.frame = CGRect(x: 55,
+                                      y: frame.minY,
+                                      width: frame.width,
+                                      height: frame.height
+            )
+        }
 
         required init?(coder aDecoder: NSCoder) {
             fatalError("init(coder:) has not been implemented")


### PR DESCRIPTION
quick patch for the imageViews in contextMenu having variable widths (between 18 and 25 pt). 

before: 
<img width="132" alt="screenshot 2018-08-10 13 58 47" src="https://user-images.githubusercontent.com/26695477/43973508-bd521e32-9ca5-11e8-812e-92a4ded6b373.png">
 
after: 
<img width="130" alt="screenshot 2018-08-10 13 59 23" src="https://user-images.githubusercontent.com/26695477/43973633-1b4c81bc-9ca6-11e8-8f19-d5f65233d120.png">

I'm reluctant to change the imageView's frames as I think the system does a good job of laying them out as is, but I'm all ears if you all have suggestions for a better way to do this. 