### PR TITLE
Clean up reactions settings

### DIFF
--- a/Classes/Issues/Comments/IssueCommentBaseCell.swift
+++ b/Classes/Issues/Comments/IssueCommentBaseCell.swift
@@ -95,15 +95,14 @@ class IssueCommentBaseCell: UICollectionViewCell, UIGestureRecognizerDelegate {
 
     // MARK: Private API
 
-    private func setUpDoubleTapIfNeeded()
-    {
-      // If reaction is set to none, no need for the double-tap
-      if ReactionContent.defaultReaction == .__unknown("Disabled") { return }
-    
-      doubleTapGesture.addTarget(self, action: #selector(onDoubleTap))
-      doubleTapGesture.numberOfTapsRequired = 2
-      doubleTapGesture.delegate = self
-      addGestureRecognizer(doubleTapGesture)
+    private func setUpDoubleTapIfNeeded() {
+        // If reaction is set to none, no need for the double-tap
+        if !ReactionContent.reactionsEnabled { return }
+
+        doubleTapGesture.addTarget(self, action: #selector(onDoubleTap))
+        doubleTapGesture.numberOfTapsRequired = 2
+        doubleTapGesture.delegate = self
+        addGestureRecognizer(doubleTapGesture)
     }
     @objc private func onDoubleTap() {
         doubleTapDelegate?.didDoubleTap(cell: self)
@@ -127,3 +126,4 @@ class IssueCommentBaseCell: UICollectionViewCell, UIGestureRecognizerDelegate {
     }
 
 }
+

--- a/Classes/Issues/Comments/IssueCommentSectionController.swift
+++ b/Classes/Issues/Comments/IssueCommentSectionController.swift
@@ -442,7 +442,7 @@ final class IssueCommentSectionController:
     // MARK: IssueCommentDoubleTapDelegate
     
     func didDoubleTap(cell: IssueCommentBaseCell) {
-        let reaction = ReactionContent.defaultReaction
+        guard let reaction = ReactionContent.defaultReaction else { return }
         guard let reactions = reactionMutation ?? self.object?.reactions,
             !reactions.viewerDidReact(reaction: reaction)
             else { return }

--- a/Classes/Issues/Comments/Reactions/Defaults+Reaction.swift
+++ b/Classes/Issues/Comments/Reactions/Defaults+Reaction.swift
@@ -6,19 +6,31 @@
 //  Copyright © 2018 Ryan Nystrom. All rights reserved.
 //
 extension UserDefaults {
-  // Stores ReactionContent in string form but
-  // accepts and returns in original form
-  static func setDefault(reaction: ReactionContent)
-  {
-    standard.set(reaction.emoji, forKey: "default.reaction")
-  }
-  
-  static var getDefaultReaction: ReactionContent
-  {
-    guard let reactionAsString = standard.string(forKey: "default.reaction")
-      else { return ReactionContent.thumbsUp }
-    let reaction = reactionAsString.reaction
-    return reaction
-  }
-  
+
+    private static let defaultKey = "com.whoisryannystrom.freetime.default-reaction"
+    private static let disabledValue = "disabled"
+
+    // Stores ReactionContent in string form but
+    // accepts and returns in original form
+    func setDefault(reaction: ReactionContent) {
+        set(reaction.emoji, forKey: UserDefaults.defaultKey)
+    }
+
+    func disableReaction() {
+        set(UserDefaults.disabledValue, forKey: UserDefaults.defaultKey)
+    }
+
+    var defaultReaction: ReactionContent? {
+        // if value doesn't exist, first access, default to previous behavior of +1
+        guard let value = string(forKey: UserDefaults.defaultKey)
+            else { return ReactionContent.thumbsUp }
+        if value == UserDefaults.disabledValue {
+            return nil
+        } else {
+            let reaction = value.reaction
+            return reaction
+        }
+    }
+
 }
+

--- a/Classes/Issues/Comments/Reactions/ReactionContent+ReactionType.swift
+++ b/Classes/Issues/Comments/Reactions/ReactionContent+ReactionType.swift
@@ -15,26 +15,30 @@ extension ReactionContent {
         case .heart: return "❤️"
         case .hooray: return "🎉"
         case .laugh: return "😄"
-        case .__unknown("Disabled"): return "Disabled"
         case .thumbsUp, .__unknown: return "👍"
         case .thumbsDown: return "👎"
         }
     }
-  
-   static var defaultReaction: ReactionContent {
-    return UserDefaults.getDefaultReaction
-   }
+
+    static var reactionsEnabled: Bool {
+        return UserDefaults.standard.defaultReaction != nil
+    }
+
+    static var defaultReaction: ReactionContent? {
+        return UserDefaults.standard.defaultReaction
+    }
 }
 extension String {
-  var reaction: ReactionContent {
-    switch self {
-    case "😕": return .confused
-    case "❤️": return .heart
-    case "🎉": return .hooray
-    case "😄": return .laugh
-    case "👍": return .thumbsUp
-    case "👎": return .thumbsDown
-    default:   return .__unknown(self)
+    var reaction: ReactionContent? {
+        switch self {
+        case "😕": return .confused
+        case "❤️": return .heart
+        case "🎉": return .hooray
+        case "😄": return .laugh
+        case "👍": return .thumbsUp
+        case "👎": return .thumbsDown
+        default:   return nil
+        }
     }
-  }
 }
+

--- a/Classes/Settings/DefaultReactionDetailController.swift
+++ b/Classes/Settings/DefaultReactionDetailController.swift
@@ -17,102 +17,99 @@ class DefaultReactionDetailController: UITableViewController {
     @IBOutlet var confusedCell: UITableViewCell!
     @IBOutlet var heartCell: UITableViewCell!
     @IBOutlet var enabledSwitch: UISwitch!
-  
+
     override func viewDidLoad() {
         super.viewDidLoad()
         checkCurrentDefault()
         tableView.reloadData()
     }
-  
+
     override func numberOfSections(in tableView: UITableView) -> Int {
-      return enabledSwitch.isOn ? 2 : 1
+        return enabledSwitch.isOn ? 2 : 1
     }
-  
+
     private func checkCurrentDefault() {
-      switch (ReactionContent.defaultReaction)
-      {
-      case ReactionContent.thumbsUp:
-        updateCells(cell: thumbsUpCell)
-      case ReactionContent.thumbsDown:
-        updateCells(cell: thumbsDownCell)
-      case ReactionContent.laugh:
-        updateCells(cell: laughCell)
-      case ReactionContent.hooray:
-        updateCells(cell: hoorayCell)
-      case ReactionContent.confused:
-        updateCells(cell: confusedCell)
-      case ReactionContent.heart:
-        updateCells(cell: heartCell)
-      case ReactionContent.__unknown("Disabled"):
-        enabledSwitch.isOn = false
-      default:
-        updateCells(cell: thumbsUpCell)
-      }
-      
+        guard let reaction = ReactionContent.defaultReaction else {
+            enabledSwitch.isOn = false
+            return
+        }
+
+        let cell: UITableViewCell
+        switch (reaction) {
+        case .thumbsUp, .__unknown: cell = thumbsUpCell
+        case .thumbsDown: cell = thumbsDownCell
+        case .laugh: cell = laughCell
+        case .hooray: cell = hoorayCell
+        case .confused: cell = confusedCell
+        case .heart: cell = heartCell
+        }
+        updateCells(cell: cell)
     }
-  
+
     private func updateCells(cell: UITableViewCell) {
-      
-      rz_smoothlyDeselectRows(tableView: self.tableView)
+        rz_smoothlyDeselectRows(tableView: self.tableView)
 
-      // Reset all to none
-      thumbsUpCell.accessoryType = .none
-      thumbsDownCell.accessoryType = .none
-      laughCell.accessoryType = .none
-      hoorayCell.accessoryType = .none
-      confusedCell.accessoryType = .none
-      heartCell.accessoryType = .none
-      
-      // Set proper cell to check
-      cell.accessoryType = .checkmark
+        // Reset all to none
+        thumbsUpCell.accessoryType = .none
+        thumbsDownCell.accessoryType = .none
+        laughCell.accessoryType = .none
+        hoorayCell.accessoryType = .none
+        confusedCell.accessoryType = .none
+        heartCell.accessoryType = .none
 
+        // Set proper cell to check
+        cell.accessoryType = .checkmark
     }
-  
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-      
-      tableView.deselectRow(at: indexPath, animated: trueUnlessReduceMotionEnabled)
-      let cell = tableView.cellForRow(at: indexPath)
-      
-      switch cell {
-      case thumbsUpCell:
-        updateDefaultReaction(.thumbsUp)
-      case thumbsDownCell:
-        updateDefaultReaction(.thumbsDown)
-      case laughCell:
-        updateDefaultReaction(.laugh)
-      case hoorayCell:
-        updateDefaultReaction(.hooray)
-      case confusedCell:
-        updateDefaultReaction(.confused)
-      case heartCell:
-        updateDefaultReaction(.heart)
-      default:
-        break
-      }
+        tableView.deselectRow(at: indexPath, animated: trueUnlessReduceMotionEnabled)
+        let cell = tableView.cellForRow(at: indexPath)
+
+        switch cell {
+        case thumbsUpCell:
+            updateDefault(reaction: .thumbsUp)
+        case thumbsDownCell:
+            updateDefault(reaction: .thumbsDown)
+        case laughCell:
+            updateDefault(reaction: .laugh)
+        case hoorayCell:
+            updateDefault(reaction: .hooray)
+        case confusedCell:
+            updateDefault(reaction: .confused)
+        case heartCell:
+            updateDefault(reaction: .heart)
+        default:
+            break
+        }
     }
-  
+
     @IBAction func toggleDefaultReaction(_ sender: Any) {
         if(enabledSwitch.isOn) {
-          updateDefaultReaction(.thumbsUp)
+            updateDefault(reaction: .thumbsUp)
         } else {
-          updateDefaultReaction(.__unknown("Disabled"))
+            disableReaction()
         }
         updateSections()
     }
-  
-    private func updateDefaultReaction(_ reaction: ReactionContent) {
-      UserDefaults.setDefault(reaction: reaction)
-      checkCurrentDefault()
+
+    private func updateDefault(reaction: ReactionContent) {
+        UserDefaults.standard.setDefault(reaction: reaction)
+        checkCurrentDefault()
     }
-  
+
+    private func disableReaction() {
+        UserDefaults.standard.disableReaction()
+    }
+
     private func updateSections() {
-      tableView.performBatchUpdates({
-        if(enabledSwitch.isOn) {
-          self.tableView.insertSections(IndexSet(integer: 1), with: .top)
-        } else {
-          self.tableView.deleteSections(IndexSet(integer: 1), with: .top)
-        }
-      }, completion: nil)
+        tableView.performBatchUpdates({
+            if(enabledSwitch.isOn) {
+                self.tableView.insertSections(IndexSet(integer: 1), with: .top)
+            } else {
+                self.tableView.deleteSections(IndexSet(integer: 1), with: .top)
+            }
+        }, completion: nil)
     }
 }
+
 

--- a/Classes/Settings/Settings.storyboard
+++ b/Classes/Settings/Settings.storyboard
@@ -382,7 +382,7 @@
                         <sections>
                             <tableViewSection id="um3-Ah-wWf">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="UJb-ob-yCk" customClass="StyledTableCell" customModule="Freetime" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="UJb-ob-yCk" customClass="StyledTableCell" customModule="Freetime" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="35" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UJb-ob-yCk" id="xcP-b2-e1A">

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -61,7 +61,8 @@ NewIssueTableViewControllerDelegate {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
       
-        defaultReactionLabel.text = ReactionContent.defaultReaction.emoji
+        defaultReactionLabel.text = ReactionContent.defaultReaction?.emoji
+            ?? NSLocalizedString("Off", comment: "")
 
         rz_smoothlyDeselectRows(tableView: tableView)
         accountsCell.detailTextLabel?.text = sessionManager.focusedUserSession?.username ?? Constants.Strings.unknown
@@ -186,7 +187,7 @@ NewIssueTableViewControllerDelegate {
     }
   
     func onSetDefaultReaction() {
-      //showDefaultReactionMenu()
+        //showDefaultReactionMenu()
     }
 
     func onSignOut() {

--- a/Classes/Views/StyledTableCell.swift
+++ b/Classes/Views/StyledTableCell.swift
@@ -27,8 +27,6 @@ class StyledTableCell: UITableViewCell {
         background.backgroundColor = Styles.Colors.Gray.alphaLighter
         selectedBackgroundView = background
     }
-  
-   override var canBecomeFirstResponder: Bool {
-      return true
-   }
+    
 }
+

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -114,6 +114,8 @@
 		292FF8B51F303BD0009E63F7 /* IssuePreviewSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292FF8B41F303BD0009E63F7 /* IssuePreviewSectionController.swift */; };
 		292FF8B71F303BD9009E63F7 /* IssuePreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292FF8B61F303BD9009E63F7 /* IssuePreviewViewController.swift */; };
 		292FF8B91F303DB0009E63F7 /* IssuePreviewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292FF8B81F303DB0009E63F7 /* IssuePreviewModel.swift */; };
+		2930988D211F327C00E1178B /* Defaults+Reaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2930988C211F327B00E1178B /* Defaults+Reaction.swift */; };
+		2930988F211F32D100E1178B /* DefaultReactionDetailController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2930988E211F32D100E1178B /* DefaultReactionDetailController.swift */; };
 		2930F2711F894AA10082BA26 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 2930F2701F894AA10082BA26 /* Settings.bundle */; };
 		2930F2731F8A27750082BA26 /* WidthCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2930F2721F8A27750082BA26 /* WidthCache.swift */; };
 		29316DB51ECC7DEB007CAE3F /* ButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29316DB41ECC7DEB007CAE3F /* ButtonCell.swift */; };
@@ -626,6 +628,8 @@
 		292FF8B41F303BD0009E63F7 /* IssuePreviewSectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssuePreviewSectionController.swift; sourceTree = "<group>"; };
 		292FF8B61F303BD9009E63F7 /* IssuePreviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssuePreviewViewController.swift; sourceTree = "<group>"; };
 		292FF8B81F303DB0009E63F7 /* IssuePreviewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssuePreviewModel.swift; sourceTree = "<group>"; };
+		2930988C211F327B00E1178B /* Defaults+Reaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Defaults+Reaction.swift"; sourceTree = "<group>"; };
+		2930988E211F32D100E1178B /* DefaultReactionDetailController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultReactionDetailController.swift; sourceTree = "<group>"; };
 		2930F2701F894AA10082BA26 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = SOURCE_ROOT; };
 		2930F2721F8A27750082BA26 /* WidthCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidthCache.swift; sourceTree = "<group>"; };
 		29316DB41ECC7DEB007CAE3F /* ButtonCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonCell.swift; sourceTree = "<group>"; };
@@ -1265,6 +1269,7 @@
 		292FCADE1EDFCC510026635E /* Reactions */ = {
 			isa = PBXGroup;
 			children = (
+				2930988C211F327B00E1178B /* Defaults+Reaction.swift */,
 				292FCADF1EDFCC510026635E /* IssueCommentReactionCell.swift */,
 				292FCB1E1EDFCD750026635E /* IssueCommentReactionViewModel.swift */,
 				2908C5881F6F3EB00071C39D /* IssueLocalReaction.swift */,
@@ -1836,6 +1841,7 @@
 		29C1677B1ECA1CED00439D62 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				2930988E211F32D100E1178B /* DefaultReactionDetailController.swift */,
 				292FF8AB1F2FD3EC009E63F7 /* Settings.storyboard */,
 				297FB7771F51128A00F2E618 /* SettingsAccountsViewController.swift */,
 				29764C131FDC4DB60095FF95 /* SettingsLabel.swift */,
@@ -2790,6 +2796,7 @@
 				293A45A21F29954000DD1006 /* IssueCommitModel.swift in Sources */,
 				293A45A61F29987C00DD1006 /* IssueCommitSectionController.swift in Sources */,
 				291929471F3EAB250012067B /* IssueDetailsModel.swift in Sources */,
+				2930988F211F32D100E1178B /* DefaultReactionDetailController.swift in Sources */,
 				29C8F9AD208C02860075931C /* LoadMoreSectionController2.swift in Sources */,
 				292CD3BB1F0AF28F00D3D57B /* IssueDiffHunkModel.swift in Sources */,
 				292CD3BF1F0AF3C000D3D57B /* IssueDiffHunkPathCell.swift in Sources */,
@@ -2868,6 +2875,7 @@
 				294563EA1EE4EEF000DBCD35 /* IssueStatusCell.swift in Sources */,
 				3E79A2FF1F8A7DA700E1126B /* ShortcutHandler.swift in Sources */,
 				29A5AF411F92677D0065D529 /* RepositoryIssueSummaryModel+Filterable.swift in Sources */,
+				2930988D211F327C00E1178B /* Defaults+Reaction.swift in Sources */,
 				295C31D11F0AA72000521CED /* IssueStatusEvent+ButtonState.swift in Sources */,
 				DCA5ED101FAEDF290072F074 /* BookmarkStore.swift in Sources */,
 				295C31CD1F0AA55400521CED /* IssueStatusEvent.swift in Sources */,


### PR DESCRIPTION
From #2022 cc @Huddie 

There were enough changes that it would've taken a while to update. Some things that I want to call out:

- Explicit "disabled" value vs hacking `"Disabled"` into the unknown value
- Localization for disabled
- Code formatting! 4-space tabs, `{` on sameline (TODO SwiftLint....)
- Fixed up some naming
- Files weren't added to .xcodeproj, build was failing