### PR TITLE
Resign keyboard on transition

### DIFF
--- a/Classes/Repository/RepositorySummarySectionController.swift
+++ b/Classes/Repository/RepositorySummarySectionController.swift
@@ -55,6 +55,7 @@ final class RepositorySummarySectionController: ListGenericSectionController<Rep
         guard let number = self.object?.number else { return }
         let issueModel = IssueDetailsModel(owner: repo.owner, repo: repo.name, number: number)
         let controller = IssuesViewController(client: client, model: issueModel)
+        viewController?.view.endEditing(false)
         viewController?.navigationController?.pushViewController(controller, animated: trueUnlessReduceMotionEnabled)
     }
 

--- a/Classes/Repository/RepositorySummarySectionController.swift
+++ b/Classes/Repository/RepositorySummarySectionController.swift
@@ -55,7 +55,7 @@ final class RepositorySummarySectionController: ListGenericSectionController<Rep
         guard let number = self.object?.number else { return }
         let issueModel = IssueDetailsModel(owner: repo.owner, repo: repo.name, number: number)
         let controller = IssuesViewController(client: client, model: issueModel)
-        viewController?.view.endEditing(false)
+        viewController?.view.endEditing(false) // resign keyboard if it was triggered to become active by SearchBar 
         viewController?.navigationController?.pushViewController(controller, animated: trueUnlessReduceMotionEnabled)
     }
 


### PR DESCRIPTION
fixes #2118 as far as I can tell. Keyboard was not resigning before pushing a new view controller onto the stack and causing some downstream sizing issues in MessageViewController. 

