### PR TITLE
Use same cell size for Search and Bookmarks

### DIFF
--- a/Classes/Bookmark/BookmarkSectionController.swift
+++ b/Classes/Bookmark/BookmarkSectionController.swift
@@ -32,7 +32,7 @@ final class BookmarkSectionController: ListGenericSectionController<BookmarkView
 
         return CGSize(
             width: width,
-            height: max(object.text.viewSize(in: width).height, Styles.Sizes.tableCellHeightLarge)
+            height: max(object.text.viewSize(in: width).height, Styles.Sizes.tableCellHeight + Styles.Sizes.rowSpacing * 2)
         )
     }
 


### PR DESCRIPTION
Fixes #2099 

**Note:**
I think we shouldn't use the same cell for Search and Bookmarks because of they different in behavior