### PR TITLE
Fixed s/nuber/number/ typo in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ never uploaded to any servers.
 GitHawk stores some repository information on the device, including source
 code, pull request contents, and issue contents. This information is stored
 for the purpose of speeding up the app's user experience and reducing the
-nuber of redundant calls it needs to make to the GitHub API. Source code and
+number of redundant calls it needs to make to the GitHub API. Source code and
 other information downloaded using the `repo` OAuth scope is never uploaded to
 any servers.
 


### PR DESCRIPTION
Just fixed a typo in the `SECURITY.md` document. This will hopefully be the smallest contribution to the project ever.