### PR TITLE
Fetch current detail controller and compare

### DIFF
--- a/Classes/Issues/IssueDetailsModel.swift
+++ b/Classes/Issues/IssueDetailsModel.swift
@@ -15,3 +15,5 @@ struct IssueDetailsModel {
     let number: Int
 
 }
+
+extension IssueDetailsModel: Equatable {}

--- a/Classes/Issues/IssueDetailsModel.swift
+++ b/Classes/Issues/IssueDetailsModel.swift
@@ -8,12 +8,10 @@
 
 import Foundation
 
-struct IssueDetailsModel {
+struct IssueDetailsModel: Equatable {
 
     let owner: String
     let repo: String
     let number: Int
 
 }
-
-extension IssueDetailsModel: Equatable {}

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -36,7 +36,7 @@ final class IssuesViewController:
     MessageTextViewListener {
 
     private let client: GithubClient
-    private let model: IssueDetailsModel
+    let model: IssueDetailsModel
     private let addCommentClient: AddCommentClient
     private let textActionsController = TextActionsController()
     private var bookmarkNavController: BookmarkNavigationController? = nil

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -35,8 +35,8 @@ final class IssuesViewController:
     IssueTextActionsViewSendDelegate,
     MessageTextViewListener {
 
-    private let client: GithubClient
     let model: IssueDetailsModel
+    private let client: GithubClient
     private let addCommentClient: AddCommentClient
     private let textActionsController = TextActionsController()
     private var bookmarkNavController: BookmarkNavigationController? = nil

--- a/Classes/Notifications/NotificationSectionController.swift
+++ b/Classes/Notifications/NotificationSectionController.swift
@@ -86,9 +86,13 @@ final class NotificationSectionController: ListSwiftSectionController<Notificati
         case .hash(let hash):
             viewController?.presentCommit(owner: model.owner, repo: model.repo, hash: hash)
         case .number(let number):
+            let model = IssueDetailsModel(owner: model.owner, repo: model.repo, number: number)
+            if let controller = currentDetailController, controller.model == model {
+                return
+            }
             let controller = IssuesViewController(
                 client: modelController.githubClient,
-                model: IssueDetailsModel(owner: model.owner, repo: model.repo, number: number),
+                model: model,
                 scrollToBottom: true
             )
             let navigation = UINavigationController(rootViewController: controller)
@@ -96,6 +100,10 @@ final class NotificationSectionController: ListSwiftSectionController<Notificati
         case .release(let release):
             showRelease(release, model: model)
         }
+    }
+    
+    private var currentDetailController: IssuesViewController? {
+        return (UIApplication.shared.delegate as? AppDelegate)?.rootNavigationManager.detailNavigationController?.topViewController as? IssuesViewController
     }
 
     private func showRelease(_ release: String, model: NotificationViewModel) {

--- a/Classes/Notifications/NotificationSectionController.swift
+++ b/Classes/Notifications/NotificationSectionController.swift
@@ -87,7 +87,7 @@ final class NotificationSectionController: ListSwiftSectionController<Notificati
             viewController?.presentCommit(owner: model.owner, repo: model.repo, hash: hash)
         case .number(let number):
             let model = IssueDetailsModel(owner: model.owner, repo: model.repo, number: number)
-            if let controller = currentDetailController, controller.model == model {
+            if let issuesViewController = currentDetailController, issuesViewController.model == model {
                 return
             }
             let controller = IssuesViewController(

--- a/Classes/Notifications/NotificationSectionController.swift
+++ b/Classes/Notifications/NotificationSectionController.swift
@@ -103,7 +103,9 @@ final class NotificationSectionController: ListSwiftSectionController<Notificati
     }
     
     private var currentDetailController: IssuesViewController? {
-        return (UIApplication.shared.delegate as? AppDelegate)?.rootNavigationManager.detailNavigationController?.topViewController as? IssuesViewController
+        let appDelegate = (UIApplication.shared.delegate as? AppDelegate)
+        let navigationController = appDelegate?.rootNavigationManager.detailNavigationController
+        return navigationController?.topViewController as? IssuesViewController
     }
 
     private func showRelease(_ release: String, model: NotificationViewModel) {

--- a/Classes/Systems/AppDelegate.swift
+++ b/Classes/Systems/AppDelegate.swift
@@ -22,7 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private let sessionManager = GitHubSessionManager()
     private var watchAppSync: WatchAppUserSessionSync?
 
-    private lazy var rootNavigationManager: RootNavigationManager = {
+    private(set) lazy var rootNavigationManager: RootNavigationManager = {
         return RootNavigationManager(
             sessionManager: self.sessionManager,
             rootViewController: self.window?.rootViewController as! UISplitViewController

--- a/Classes/Systems/RootNavigationManager.swift
+++ b/Classes/Systems/RootNavigationManager.swift
@@ -146,7 +146,7 @@ final class RootNavigationManager: GitHubSessionListener {
         }
     }
 
-    private var detailNavigationController: UINavigationController? {
+    var detailNavigationController: UINavigationController? {
         return rootViewController?.viewControllers.last as? UINavigationController
     }
 


### PR DESCRIPTION
This pull request prevents the detail view from being reloaded unnecessarily. Which closes the following.

Closes #244 