### PR TITLE
adds review GitHubAccess button to notifications view controller

### DIFF
--- a/Classes/Notifications/NoNewNotificationsCell.swift
+++ b/Classes/Notifications/NoNewNotificationsCell.swift
@@ -9,11 +9,17 @@
 import UIKit
 import SnapKit
 
+protocol ReviewGitHubAccessDelegate: class {
+    func reviewGitHubAccessButtonTapped()
+}
+
 final class NoNewNotificationsCell: UICollectionViewCell {
 
     let emojiLabel = UILabel()
     let messageLabel = UILabel()
     let shadow = CAShapeLayer()
+    let reviewGitHubAccessButton = UIButton()
+    weak var reviewGitHubAccessDelegate: ReviewGitHubAccessDelegate?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -54,6 +60,27 @@ final class NoNewNotificationsCell: UICollectionViewCell {
 
         contentView.isAccessibilityElement = true
         contentView.accessibilityLabel = NSLocalizedString("You have no new notifications!", comment: "Inbox Zero Accessibility Label")
+        
+        
+        //configure reviewGitHubAcess button
+        reviewGitHubAccessButton.setTitle(Constants.Strings.reviewGitHubAccess, for: .normal)
+        reviewGitHubAccessButton.isAccessibilityElement = false
+        reviewGitHubAccessButton.titleLabel?.textAlignment = .center
+        reviewGitHubAccessButton.backgroundColor = .clear
+        reviewGitHubAccessButton.titleLabel?.font = Styles.Text.finePrint.preferredFont
+        reviewGitHubAccessButton.setTitleColor(Styles.Colors.Gray.light.color, for: .normal)
+        reviewGitHubAccessButton.addTarget(self, action: #selector(reviewGitHubAccessButtonTapped),
+                                           for: .touchUpInside)
+        contentView.addSubview(reviewGitHubAccessButton)
+        let buttonWidth = (reviewGitHubAccessButton.titleLabel?.intrinsicContentSize.width ?? 0) + Styles.Sizes.gutter
+        let buttonHeight = (reviewGitHubAccessButton.titleLabel?.intrinsicContentSize.height ?? 0) + Styles.Sizes.gutter
+        reviewGitHubAccessButton.snp.makeConstraints { make in
+            make.centerX.equalTo(messageLabel)
+            make.width.equalTo(buttonWidth)
+            make.height.equalTo(buttonHeight)
+            make.bottom.equalTo(contentView.snp.bottom).offset(-Styles.Sizes.tableSectionSpacing)
+        }
+        
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -89,9 +116,13 @@ final class NoNewNotificationsCell: UICollectionViewCell {
 
     // MARK: Public API
 
-    func configure(emoji: String, message: String) {
+    func configure(emoji: String,
+                   message: String,
+                   reviewGitHubAccessDelegate: ReviewGitHubAccessDelegate?)
+    {
         emojiLabel.text = emoji
         messageLabel.text = message
+        self.reviewGitHubAccessDelegate = reviewGitHubAccessDelegate
     }
 
     // MARK: Private API
@@ -119,5 +150,9 @@ final class NoNewNotificationsCell: UICollectionViewCell {
 
         shadow.add(shadowScale, forKey: "nonewnotificationscell.shadow")
     }
-
+    
+    @objc func reviewGitHubAccessButtonTapped() {
+        reviewGitHubAccessDelegate?.reviewGitHubAccessButtonTapped()
+    }
+    
 }

--- a/Classes/Notifications/NoNewNotificationsSectionController.swift
+++ b/Classes/Notifications/NoNewNotificationsSectionController.swift
@@ -13,10 +13,12 @@ final class NoNewNotificationSectionController: ListSwiftSectionController<Strin
 
     private let layoutInsets: UIEdgeInsets
     private let loader = InboxZeroLoader()
+    weak var reviewGitHubAccessDelegate: ReviewGitHubAccessDelegate?
 
-    init(layoutInsets: UIEdgeInsets) {
+    init(layoutInsets: UIEdgeInsets, reviewGitHubAccessDelegate: ReviewGitHubAccessDelegate) {
         self.layoutInsets = layoutInsets
         super.init()
+        self.reviewGitHubAccessDelegate = reviewGitHubAccessDelegate
         loader.load { [weak self] success in
             if success {
                 self?.update()
@@ -36,10 +38,14 @@ final class NoNewNotificationSectionController: ListSwiftSectionController<Strin
                         height: $0.collection.containerSize.height - layoutInsets.top - layoutInsets.bottom
                     )
             },
-                configure: {
+                configure: { [weak self] in
+                    guard let strongSelf = self else { return }
                     // TODO accessing the value seems to be required for this to compile
                     print($1.value)
-                    $0.configure(emoji: latest.emoji, message: latest.message)
+                    $0.configure(emoji: latest.emoji,
+                                 message: latest.message,
+                                 reviewGitHubAccessDelegate: strongSelf.reviewGitHubAccessDelegate
+                    )
                 })
         ]
     }

--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -16,7 +16,9 @@ BaseListViewController2DataSource,
 ForegroundHandlerDelegate,
 FlatCacheListener,
 TabNavRootViewControllerType,
-BaseListViewController2EmptyDataSource {
+BaseListViewController2EmptyDataSource,
+ReviewGitHubAccessDelegate
+{
 
     private let modelController: NotificationModelController
     private let foreground = ForegroundHandler(threshold: 5 * 60)
@@ -278,7 +280,10 @@ BaseListViewController2EmptyDataSource {
     func emptyModel(for adapter: ListSwiftAdapter) -> ListSwiftPair {
         let layoutInsets = view.safeAreaInsets
         return ListSwiftPair.pair("empty-notification-value", {
-            return NoNewNotificationSectionController(layoutInsets: layoutInsets)
+            return NoNewNotificationSectionController(
+                layoutInsets: layoutInsets,
+                reviewGitHubAccessDelegate: self
+		)
         })
     }
 
@@ -304,4 +309,14 @@ BaseListViewController2EmptyDataSource {
     func didDoubleTapTab() {
         didSingleTapTab()
     }
+    
+    // MARK: ReviewGitHubAccessDelegate
+    func reviewGitHubAccessButtonTapped() {
+        //copied/pasted from SettingsViewController... could consolidate
+        guard let url = URL(string: "https://github.com/settings/connections/applications/\(Secrets.GitHub.clientId)")
+            else { fatalError("Should always create GitHub issue URL") }
+        // iOS 11 login uses SFAuthenticationSession which shares credentials with Safari.app
+        UIApplication.shared.open(url)
+    }
+    
 }

--- a/Classes/Views/Constants.swift
+++ b/Classes/Views/Constants.swift
@@ -53,5 +53,6 @@ enum Constants {
         static let milestone = NSLocalizedString("Milestone", comment: "")
         static let assignees = NSLocalizedString("Assignees", comment: "")
         static let reviewers = NSLocalizedString("Reviewers", comment: "")
+        static let reviewGitHubAccess = NSLocalizedString("Review GitHub Access", comment: "")
     }
 }

--- a/Classes/Views/Styles.swift
+++ b/Classes/Views/Styles.swift
@@ -67,6 +67,7 @@ enum Styles {
         static let code = TextStyle(font: .name("Courier"), size: 16)
         static let codeBold = TextStyle(font: .name("Courier-Bold"), size: 16)
         static let secondaryCode = TextStyle(font: .name("Courier"), size: 13)
+        static let finePrint = TextStyle(size: 12)
 
         static let h1 = TextStyle(font: .system(.bold), size: 24)
         static let h2 = TextStyle(font: .system(.bold), size: 20)


### PR DESCRIPTION
Updated from #2085 

If you want to see how it looks on your sim, return an empty array [here](https://github.com/GitHawkApp/GitHawk/blob/966cb1a4d1238bc2e92a42afbaacd3b6ba497d6e/Classes/Notifications/NotificationsViewController.swift#L266)

Final: 

<img width="304" alt="screenshot 2018-09-23 13 22 58" src="https://user-images.githubusercontent.com/26695477/45930906-d1450980-bf33-11e8-93c8-4d4c8815cdee.png">
