### PR TITLE
allows setting Milestone's loading indicator's color 

### DIFF
--- a/Classes/Labels/LabelsViewController.swift
+++ b/Classes/Labels/LabelsViewController.swift
@@ -30,6 +30,7 @@ final class LabelsViewController: BaseListViewController2<String>, BaseListViewC
         preferredContentSize = Styles.Sizes.contextMenuSize
         title = Constants.Strings.labels
         feed.collectionView.backgroundColor = Styles.Colors.menuBackgroundColor.color
+        feed.setLoadingSpinnerColor(to: .white)
         dataSource = self
     }
 

--- a/Classes/Milestones/MilestonesViewController.swift
+++ b/Classes/Milestones/MilestonesViewController.swift
@@ -43,8 +43,8 @@ MilestoneSectionControllerDelegate {
         title = Constants.Strings.milestone
         preferredContentSize = Styles.Sizes.contextMenuSize
         feed.collectionView.backgroundColor = Styles.Colors.menuBackgroundColor.color
-        dataSource = self
         feed.setLoadingSpinnerColor(to: .white)
+        dataSource = self
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Classes/Milestones/MilestonesViewController.swift
+++ b/Classes/Milestones/MilestonesViewController.swift
@@ -44,6 +44,7 @@ MilestoneSectionControllerDelegate {
         preferredContentSize = Styles.Sizes.contextMenuSize
         feed.collectionView.backgroundColor = Styles.Colors.menuBackgroundColor.color
         dataSource = self
+        feed.setLoadingSpinnerColor(to: .white)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Classes/People/PeopleViewController.swift
+++ b/Classes/People/PeopleViewController.swift
@@ -55,6 +55,7 @@ PeopleSectionControllerDelegate {
         }
 
         feed.collectionView.backgroundColor = Styles.Colors.menuBackgroundColor.color
+        feed.setLoadingSpinnerColor(to: .white)
         preferredContentSize = Styles.Sizes.contextMenuSize
         updateSelectionCount()
     }

--- a/Classes/Systems/Feed.swift
+++ b/Classes/Systems/Feed.swift
@@ -66,6 +66,10 @@ final class Feed: NSObject, UIScrollViewDelegate {
     func showEmptyLoadingView() {
         loadingView.isHidden = false
     }
+    
+    func setLoadingSpinnerColor(to color: UIColor) {
+        loadingView.setSpinnerColor(to: color)
+    }
 
     func viewDidLoad() {
         guard let view = adapter.viewController?.view else { return }

--- a/Classes/Views/EmptyLoadingView.swift
+++ b/Classes/Views/EmptyLoadingView.swift
@@ -17,6 +17,10 @@ final class EmptyLoadingView: UIView {
         activity.startAnimating()
         addSubview(activity)
     }
+    
+    func setSpinnerColor(to color: UIColor) {
+        activity.color = color 
+    }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")


### PR DESCRIPTION
The loading spinner's default color was grey and that comes off as hard to see against Milestone's background: 

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/26695477/46177572-5ce6cf00-c281-11e8-9506-eef72eb58e8a.gif)

Updated to white it is more visible: 

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/26695477/46177602-7f78e800-c281-11e8-91f5-03b489ed8167.gif)



