### PR TITLE
3 dot icon

### DIFF
--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -59,7 +59,7 @@ ReviewGitHubAccessDelegate
         switch inboxType {
         case .unread:
             let item = UIBarButtonItem(
-                image: UIImage(named: "filter"),
+                image: UIImage(named: "bullets-hollow"),
                 style: .plain,
                 target: self,
                 action: #selector(NotificationsViewController.onMore(sender:))


### PR DESCRIPTION
I think the filter icon @rnystrom showed from noun project is good so this is unnecessary if we go with that one. But until then this fixes a mistake where the image name was changed in one of my merges. 