### PR TITLE
Fixed cell border on merge button

### DIFF
--- a/Classes/Issues/Merge/IssueMergeSectionController.swift
+++ b/Classes/Issues/Merge/IssueMergeSectionController.swift
@@ -171,7 +171,9 @@ ListBindingSectionControllerSelectionDelegate {
             else { fatalError() }
 
         if let cell = cell as? CardCollectionViewCell {
-            cell.border = index == 0 ? .head : index == self.viewModels.count - 1 ? .tail : .neck
+            cell.border = index == 0
+                ? index == self.viewModels.count - 1 ? .full : .head
+                : index == self.viewModels.count - 1 ? .tail : .neck
         }
         if let cell = cell as? IssueMergeButtonCell {
             cell.delegate = self

--- a/Classes/Views/CardCollectionViewCell.swift
+++ b/Classes/Views/CardCollectionViewCell.swift
@@ -9,54 +9,55 @@
 import UIKit
 
 class CardCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate {
-
+    
     enum BorderType {
         case head
         case neck
         case tail
+        case full
     }
-
+    
     var border: BorderType = .neck {
         didSet { setNeedsLayout() }
     }
-
+    
     private let borderLayer = CAShapeLayer()
     private let backgroundLayer = CAShapeLayer()
-
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
-
+        
         contentView.clipsToBounds = true
-
+        
         // insert above contentView layer
         borderLayer.strokeColor = UIColor.red.cgColor
         borderLayer.strokeColor = Styles.Colors.Gray.border.color.cgColor
         borderLayer.lineWidth = 1 / UIScreen.main.scale
         borderLayer.fillColor = nil
         layer.addSublayer(borderLayer)
-
+        
         // insert as base layer
         backgroundLayer.strokeColor = nil
         backgroundLayer.fillColor = UIColor.white.cgColor
         layer.insertSublayer(backgroundLayer, at: 0)
     }
-
+    
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     override func layoutSubviews() {
         super.layoutSubviews()
         layoutContentViewForSafeAreaInsets()
-
+        
         let bounds = contentView.frame
         let inset = borderLayer.lineWidth / 2
         let pixelSnapBounds = bounds.insetBy(dx: inset, dy: inset)
         let cornerRadius = Styles.Sizes.cardCornerRadius
-
+        
         let borderPath = UIBezierPath()
         let fillPath: UIBezierPath
-
+        
         switch border {
         case .head:
             borderPath.move(to: CGPoint(x: pixelSnapBounds.minX, y: bounds.maxY))
@@ -71,7 +72,7 @@ class CardCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate 
                 controlPoint: CGPoint(x: pixelSnapBounds.maxX, y: pixelSnapBounds.minY)
             )
             borderPath.addLine(to: CGPoint(x: pixelSnapBounds.maxX, y: bounds.maxY))
-
+            
             fillPath = borderPath.copy() as! UIBezierPath
             fillPath.close()
         case .neck:
@@ -79,7 +80,7 @@ class CardCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate 
             borderPath.addLine(to: CGPoint(x: pixelSnapBounds.minX, y: bounds.maxY))
             borderPath.move(to: CGPoint(x: pixelSnapBounds.maxX, y: bounds.minY))
             borderPath.addLine(to: CGPoint(x: pixelSnapBounds.maxX, y: bounds.maxY))
-
+            
             fillPath = UIBezierPath(rect: bounds)
         case .tail:
             borderPath.move(to: CGPoint(x: pixelSnapBounds.minX, y: bounds.minY))
@@ -94,17 +95,58 @@ class CardCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate 
                 controlPoint: CGPoint(x: pixelSnapBounds.maxX, y: pixelSnapBounds.maxY)
             )
             borderPath.addLine(to: CGPoint(x: pixelSnapBounds.maxX, y: bounds.minY))
-
+            
+            fillPath = borderPath.copy() as! UIBezierPath
+            fillPath.close()
+        case .full:
+            
+            borderPath.move(to: CGPoint(x: pixelSnapBounds.minX,
+                                        y: bounds.maxY - cornerRadius))
+            borderPath.addLine(to: CGPoint(x: pixelSnapBounds.minX,
+                                           y: pixelSnapBounds.minY + cornerRadius))
+            
+            borderPath.addQuadCurve(
+                to: CGPoint(x: pixelSnapBounds.minX + cornerRadius,
+                            y: pixelSnapBounds.minY),
+                controlPoint: CGPoint(x: pixelSnapBounds.minX,
+                                      y: pixelSnapBounds.minY)
+            )
+            borderPath.addLine(to: CGPoint(x: pixelSnapBounds.maxX - cornerRadius,
+                                           y: pixelSnapBounds.minY))
+            
+            borderPath.addQuadCurve(
+                to: CGPoint(x: pixelSnapBounds.maxX,
+                            y: pixelSnapBounds.minY + cornerRadius),
+                controlPoint: CGPoint(x: pixelSnapBounds.maxX,
+                                      y: pixelSnapBounds.minY)
+            )
+            borderPath.addLine(to: CGPoint(x: pixelSnapBounds.maxX,
+                                           y: pixelSnapBounds.maxY - cornerRadius))
+            
+            borderPath.addQuadCurve(
+                to: CGPoint(x: pixelSnapBounds.maxX - cornerRadius,
+                            y: pixelSnapBounds.maxY),
+                controlPoint: CGPoint(x: pixelSnapBounds.maxX,
+                                      y: pixelSnapBounds.maxY)
+            )
+            borderPath.addLine(to: CGPoint(x: pixelSnapBounds.minX + cornerRadius,
+                                           y: bounds.maxY))
+            borderPath.addQuadCurve(
+                to: CGPoint(x: pixelSnapBounds.minX,
+                            y: pixelSnapBounds.maxY - cornerRadius),
+                controlPoint: CGPoint(x: pixelSnapBounds.minX,
+                                      y: pixelSnapBounds.maxY)
+            )
             fillPath = borderPath.copy() as! UIBezierPath
             fillPath.close()
         }
         borderLayer.path = borderPath.cgPath
         backgroundLayer.path = fillPath.cgPath
-
+        
         borderLayer.frame = self.bounds
         backgroundLayer.frame = self.bounds
     }
-
+    
     override var backgroundColor: UIColor? {
         get {
             guard let color = backgroundLayer.fillColor else { return nil }
@@ -112,5 +154,6 @@ class CardCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate 
         }
         set { backgroundLayer.fillColor = newValue?.cgColor}
     }
-
+    
 }
+

--- a/Classes/Views/CardCollectionViewCell.swift
+++ b/Classes/Views/CardCollectionViewCell.swift
@@ -9,55 +9,55 @@
 import UIKit
 
 class CardCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate {
-    
+
     enum BorderType {
         case head
         case neck
         case tail
         case full
     }
-    
+
     var border: BorderType = .neck {
         didSet { setNeedsLayout() }
     }
-    
+
     private let borderLayer = CAShapeLayer()
     private let backgroundLayer = CAShapeLayer()
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         contentView.clipsToBounds = true
-        
+
         // insert above contentView layer
         borderLayer.strokeColor = UIColor.red.cgColor
         borderLayer.strokeColor = Styles.Colors.Gray.border.color.cgColor
         borderLayer.lineWidth = 1 / UIScreen.main.scale
         borderLayer.fillColor = nil
         layer.addSublayer(borderLayer)
-        
+
         // insert as base layer
         backgroundLayer.strokeColor = nil
         backgroundLayer.fillColor = UIColor.white.cgColor
         layer.insertSublayer(backgroundLayer, at: 0)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func layoutSubviews() {
         super.layoutSubviews()
         layoutContentViewForSafeAreaInsets()
-        
+
         let bounds = contentView.frame
         let inset = borderLayer.lineWidth / 2
         let pixelSnapBounds = bounds.insetBy(dx: inset, dy: inset)
         let cornerRadius = Styles.Sizes.cardCornerRadius
-        
+
         let borderPath = UIBezierPath()
         let fillPath: UIBezierPath
-        
+
         switch border {
         case .head:
             borderPath.move(to: CGPoint(x: pixelSnapBounds.minX, y: bounds.maxY))
@@ -72,7 +72,7 @@ class CardCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate 
                 controlPoint: CGPoint(x: pixelSnapBounds.maxX, y: pixelSnapBounds.minY)
             )
             borderPath.addLine(to: CGPoint(x: pixelSnapBounds.maxX, y: bounds.maxY))
-            
+
             fillPath = borderPath.copy() as! UIBezierPath
             fillPath.close()
         case .neck:
@@ -80,7 +80,7 @@ class CardCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate 
             borderPath.addLine(to: CGPoint(x: pixelSnapBounds.minX, y: bounds.maxY))
             borderPath.move(to: CGPoint(x: pixelSnapBounds.maxX, y: bounds.minY))
             borderPath.addLine(to: CGPoint(x: pixelSnapBounds.maxX, y: bounds.maxY))
-            
+
             fillPath = UIBezierPath(rect: bounds)
         case .tail:
             borderPath.move(to: CGPoint(x: pixelSnapBounds.minX, y: bounds.minY))
@@ -95,58 +95,47 @@ class CardCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate 
                 controlPoint: CGPoint(x: pixelSnapBounds.maxX, y: pixelSnapBounds.maxY)
             )
             borderPath.addLine(to: CGPoint(x: pixelSnapBounds.maxX, y: bounds.minY))
-            
+
             fillPath = borderPath.copy() as! UIBezierPath
             fillPath.close()
         case .full:
-            
-            borderPath.move(to: CGPoint(x: pixelSnapBounds.minX,
-                                        y: bounds.maxY - cornerRadius))
-            borderPath.addLine(to: CGPoint(x: pixelSnapBounds.minX,
-                                           y: pixelSnapBounds.minY + cornerRadius))
-            
+
+            borderPath.move(to: CGPoint(x: pixelSnapBounds.minX, y: bounds.maxY - cornerRadius))
+            borderPath.addLine(to: CGPoint(x: pixelSnapBounds.minX, y: pixelSnapBounds.minY + cornerRadius))
+
             borderPath.addQuadCurve(
-                to: CGPoint(x: pixelSnapBounds.minX + cornerRadius,
-                            y: pixelSnapBounds.minY),
-                controlPoint: CGPoint(x: pixelSnapBounds.minX,
-                                      y: pixelSnapBounds.minY)
+                to: CGPoint(x: pixelSnapBounds.minX + cornerRadius, y: pixelSnapBounds.minY),
+                controlPoint: CGPoint(x: pixelSnapBounds.minX, y: pixelSnapBounds.minY)
             )
-            borderPath.addLine(to: CGPoint(x: pixelSnapBounds.maxX - cornerRadius,
-                                           y: pixelSnapBounds.minY))
+            borderPath.addLine(to: CGPoint(x: pixelSnapBounds.maxX - cornerRadius, y: pixelSnapBounds.minY))
+
+            borderPath.addQuadCurve(
+                to: CGPoint(x: pixelSnapBounds.maxX, y: pixelSnapBounds.minY + cornerRadius),
+                controlPoint: CGPoint(x: pixelSnapBounds.maxX, y: pixelSnapBounds.minY)
+            )
+            borderPath.addLine(to: CGPoint(x: pixelSnapBounds.maxX, y: pixelSnapBounds.maxY - cornerRadius))
+
+            borderPath.addQuadCurve(
+                to: CGPoint(x: pixelSnapBounds.maxX - cornerRadius, y: pixelSnapBounds.maxY),
+                controlPoint: CGPoint(x: pixelSnapBounds.maxX, y: pixelSnapBounds.maxY)
+            )
+            borderPath.addLine(to: CGPoint(x: pixelSnapBounds.minX + cornerRadius, y: bounds.maxY))
+
+            borderPath.addQuadCurve(
+                to: CGPoint(x: pixelSnapBounds.minX, y: pixelSnapBounds.maxY - cornerRadius),
+                controlPoint: CGPoint(x: pixelSnapBounds.minX, y: pixelSnapBounds.maxY)
+            )
             
-            borderPath.addQuadCurve(
-                to: CGPoint(x: pixelSnapBounds.maxX,
-                            y: pixelSnapBounds.minY + cornerRadius),
-                controlPoint: CGPoint(x: pixelSnapBounds.maxX,
-                                      y: pixelSnapBounds.minY)
-            )
-            borderPath.addLine(to: CGPoint(x: pixelSnapBounds.maxX,
-                                           y: pixelSnapBounds.maxY - cornerRadius))
-            
-            borderPath.addQuadCurve(
-                to: CGPoint(x: pixelSnapBounds.maxX - cornerRadius,
-                            y: pixelSnapBounds.maxY),
-                controlPoint: CGPoint(x: pixelSnapBounds.maxX,
-                                      y: pixelSnapBounds.maxY)
-            )
-            borderPath.addLine(to: CGPoint(x: pixelSnapBounds.minX + cornerRadius,
-                                           y: bounds.maxY))
-            borderPath.addQuadCurve(
-                to: CGPoint(x: pixelSnapBounds.minX,
-                            y: pixelSnapBounds.maxY - cornerRadius),
-                controlPoint: CGPoint(x: pixelSnapBounds.minX,
-                                      y: pixelSnapBounds.maxY)
-            )
             fillPath = borderPath.copy() as! UIBezierPath
             fillPath.close()
         }
         borderLayer.path = borderPath.cgPath
         backgroundLayer.path = fillPath.cgPath
-        
+
         borderLayer.frame = self.bounds
         backgroundLayer.frame = self.bounds
     }
-    
+
     override var backgroundColor: UIColor? {
         get {
             guard let color = backgroundLayer.fillColor else { return nil }
@@ -154,6 +143,7 @@ class CardCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate 
         }
         set { backgroundLayer.fillColor = newValue?.cgColor}
     }
-    
+
 }
+
 


### PR DESCRIPTION
The issue before was caused by the fact that we never had less than 2 cells for the mergeSectionController to render. (Summary + Merge Button) 
Our border enum had 3 options, head, tail, neck which works well for 2+ cells (Head + Tail) but with only 1 we had issues (Just summary cell since the button is not added).

I added .full to the enum and checked if the head = the tail. 
