### PR TITLE
Move lock

### DIFF
--- a/Classes/Issues/IssueManagingContextController.swift
+++ b/Classes/Issues/IssueManagingContextController.swift
@@ -142,18 +142,26 @@ final class IssueManagingContextController: NSObject, ContextMenuDelegate {
 
         let separator: Bool
         switch action {
-        case .reopen, .close: separator = true
+        case .lock, .unlock: separator = true
+        case .reopen, .close: separator = permissions != .collaborator
         default: separator = false
         }
 
         let iconColor: UIColor
         switch action {
+        case .lock: iconColor = Styles.Colors.Gray.light.color
         case .close: iconColor = Styles.Colors.Red.medium.color
         default: iconColor = Styles.Colors.Blue.medium.color
         }
 
-        return ContrastContextMenuItem(title: title, iconName: iconName, iconColor: iconColor,
-                                       separator: separator, action: actionBlock(action))
+        return ContrastContextMenuItem(
+            title: title,
+            iconName: iconName,
+            iconColor:
+            iconColor,
+            separator: separator,
+            action: actionBlock(action)
+        )
 
     }
 

--- a/Classes/Issues/IssueManagingContextController.swift
+++ b/Classes/Issues/IssueManagingContextController.swift
@@ -157,8 +157,7 @@ final class IssueManagingContextController: NSObject, ContextMenuDelegate {
         return ContrastContextMenuItem(
             title: title,
             iconName: iconName,
-            iconColor:
-            iconColor,
+            iconColor: iconColor,
             separator: separator,
             action: actionBlock(action)
         )

--- a/Classes/Issues/IssueManagingContextController.swift
+++ b/Classes/Issues/IssueManagingContextController.swift
@@ -140,6 +140,8 @@ final class IssueManagingContextController: NSObject, ContextMenuDelegate {
             iconName = "x"
         }
 
+        // Lock always has the divider above it assuming you're a collaborator.
+        // If you aren't a collaborator (Lock does not show), close has the divider above it.
         let separator: Bool
         switch action {
         case .lock, .unlock: separator = true


### PR DESCRIPTION
Moves lock under divider.

Lock always has the divider above it assuming your a collaborator.
If you aren't a collaborator (Lock does not show), close has the divider above it.

Lock's color was switched to light gray.