### PR TITLE
Add "Try Again" button for EmptyView (#2214)

### DIFF
--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -34,6 +34,7 @@ final class IssuesViewController:
     FlatCacheListener,
     IssueCommentSectionControllerDelegate,
     IssueTextActionsViewSendDelegate,
+    EmptyViewDelegate,
     MessageTextViewListener {
 
     private let client: GithubClient
@@ -501,6 +502,8 @@ final class IssuesViewController:
         case .idle:
             let emptyView = EmptyView()
             emptyView.label.text = NSLocalizedString("Issue cannot be found", comment: "")
+            emptyView.delegate = self
+            emptyView.button.isHidden = false
             return emptyView
         case .loading, .loadingNext:
             return nil
@@ -613,6 +616,12 @@ final class IssuesViewController:
                 body: text
             )
         }
+    }
+
+    // MARK: EmptyViewDelegate
+
+    func didTapRetry() {
+        self.feed.refreshHead()
     }
 
     // MARK: MessageTextViewListener

--- a/Classes/PullRequestReviews/PullRequestReviewCommentsViewController.swift
+++ b/Classes/PullRequestReviews/PullRequestReviewCommentsViewController.swift
@@ -16,6 +16,7 @@ final class PullRequestReviewCommentsViewController: MessageViewController,
     ListAdapterDataSource,
     FeedDelegate,
     PullRequestReviewReplySectionControllerDelegate,
+    EmptyViewDelegate,
     IssueTextActionsViewSendDelegate {
 
     private let model: IssueDetailsModel
@@ -169,6 +170,8 @@ final class PullRequestReviewCommentsViewController: MessageViewController,
         case .idle:
             let emptyView = EmptyView()
             emptyView.label.text = NSLocalizedString("Error loading review comments.", comment: "")
+            emptyView.delegate = self
+            emptyView.button.isHidden = false
             return emptyView
         case .loadingNext:
             return nil
@@ -185,6 +188,12 @@ final class PullRequestReviewCommentsViewController: MessageViewController,
         feed.adapter.scroll(to: reply, padding: Styles.Sizes.rowSpacing)
 
         focusedReplyModel = reply
+    }
+
+    // MARK: EmptyViewDelegate
+
+    func didTapRetry() {
+        self.feed.refreshHead()
     }
 
     // MARK: IssueTextActionsViewSendDelegate

--- a/Classes/Repository/RepositoryCodeBlobViewController.swift
+++ b/Classes/Repository/RepositoryCodeBlobViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Squawk
 
-final class RepositoryCodeBlobViewController: UIViewController {
+final class RepositoryCodeBlobViewController: UIViewController, EmptyViewDelegate {
 
     private let client: GithubClient
     private let branch: String
@@ -55,6 +55,8 @@ final class RepositoryCodeBlobViewController: UIViewController {
         view.backgroundColor = .white
 
         emptyView.isHidden = true
+        emptyView.delegate = self
+        emptyView.button.isHidden = false
         view.addSubview(emptyView)
         view.addSubview(codeView)
 
@@ -134,6 +136,12 @@ final class RepositoryCodeBlobViewController: UIViewController {
         emptyView.isHidden = true
         didFetchPayload(text)
         codeView.set(code: text)
+    }
+
+    // MARK: EmptyViewDelegate
+
+    func didTapRetry() {
+        self.onRefresh()
     }
 
 }

--- a/Classes/Repository/RepositoryWebViewController.swift
+++ b/Classes/Repository/RepositoryWebViewController.swift
@@ -129,6 +129,16 @@ extension RepositoryWebViewController: WKNavigationDelegate {
 
 }
 
+// MARK: - RepositoryWebViewController (EmptyViewDelegate) -
+
+extension RepositoryWebViewController: EmptyViewDelegate {
+
+    func didTapRetry() {
+        self.fetch()
+    }
+
+}
+
 // MARK: - RepositoryWebViewController (Fetch Data) -
 
 extension RepositoryWebViewController {
@@ -179,6 +189,8 @@ extension RepositoryWebViewController {
 
         state = .idle
         emptyView.isHidden = true
+        emptyView.delegate = self
+        emptyView.button.isHidden = false
 
         view.backgroundColor = .white
         view.addSubview(emptyView)

--- a/Classes/Search/SearchViewController.swift
+++ b/Classes/Search/SearchViewController.swift
@@ -14,11 +14,12 @@ class SearchViewController: UIViewController,
     ListAdapterDataSource,
     PrimaryViewController,
     UISearchBarDelegate,
-InitialEmptyViewDelegate,
-SearchRecentSectionControllerDelegate,
-SearchRecentHeaderSectionControllerDelegate,
-TabNavRootViewControllerType,
-SearchResultSectionControllerDelegate {
+    EmptyViewDelegate,
+    InitialEmptyViewDelegate,
+    SearchRecentSectionControllerDelegate,
+    SearchRecentHeaderSectionControllerDelegate,
+    TabNavRootViewControllerType,
+    SearchResultSectionControllerDelegate {
 
     private let client: GithubClient
     private let noResultsKey = "com.freetime.SearchViewController.no-results-key" as ListDiffable
@@ -188,6 +189,8 @@ SearchResultSectionControllerDelegate {
         case .error:
             let view = EmptyView()
             view.label.text = NSLocalizedString("Error finding results", comment: "")
+            view.delegate = self
+            view.button.isHidden = false
             return view
          case .results:
             return nil
@@ -224,6 +227,15 @@ SearchResultSectionControllerDelegate {
 
         state = .idle
         update(animated: false)
+    }
+
+    // MARK: EmptyViewDelegate
+
+    func didTapRetry() {
+        searchBar.resignFirstResponder()
+
+        guard let term = searchTerm(for: searchBar.text) else { return }
+        search(term: term)
     }
 
     // MARK: InitialEmptyViewDelegate

--- a/Classes/View Controllers/BaseListViewController.swift
+++ b/Classes/View Controllers/BaseListViewController.swift
@@ -31,6 +31,7 @@ protocol BaseListViewControllerDataSource: class {
 class BaseListViewController<PagingType: ListDiffable>: UIViewController,
 ListAdapterDataSource,
 FeedDelegate,
+EmptyViewDelegate,
 LoadMoreSectionControllerDelegate {
 
     // required on init
@@ -160,6 +161,8 @@ LoadMoreSectionControllerDelegate {
         guard hasError else { return nil }
         let empty = EmptyView()
         empty.label.text = emptyErrorMessage
+        empty.delegate = self
+        empty.button.isHidden = false
         return empty
     }
 
@@ -172,6 +175,12 @@ LoadMoreSectionControllerDelegate {
 
     final func loadNextPage(feed: Feed) -> Bool {
         return false
+    }
+
+    // MARK: EmptyViewDelegate
+
+    func didTapRetry() {
+        self.feed.refreshHead()
     }
 
     // MARK: LoadMoreSectionControllerDelegate

--- a/Classes/Views/Constants.swift
+++ b/Classes/Views/Constants.swift
@@ -56,5 +56,6 @@ enum Constants {
         static let assignees = NSLocalizedString("Assignees", comment: "")
         static let reviewers = NSLocalizedString("Reviewers", comment: "")
         static let reviewGitHubAccess = NSLocalizedString("Review GitHub Access", comment: "")
+        static let tryAgain = NSLocalizedString("Try Again", comment: "")
     }
 }

--- a/Classes/Views/EmptyView.swift
+++ b/Classes/Views/EmptyView.swift
@@ -9,9 +9,15 @@
 import UIKit
 import SnapKit
 
+protocol EmptyViewDelegate: class {
+    func didTapRetry()
+}
+
 final class EmptyView: UIView {
 
     let label = UILabel()
+    let button = UIButton(type: .system)
+    var delegate: EmptyViewDelegate?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -22,9 +28,22 @@ final class EmptyView: UIView {
         label.textColor = Styles.Colors.Gray.medium.color
         label.numberOfLines = 0
         addSubview(label)
+
+        button.isHidden = true
+        button.titleLabel?.font = Styles.Text.button.preferredFont
+        button.setTitle(Constants.Strings.tryAgain, for: .normal)
+        button.setTitleColor(Styles.Colors.Blue.medium.color, for: .normal)
+        button.addTarget(self, action: #selector(tapRetry), for: .touchUpInside)
+        addSubview(button)
+
         label.snp.makeConstraints { make in
             make.center.equalTo(self)
             make.width.lessThanOrEqualToSuperview().offset(-Styles.Sizes.gutter)
+        }
+
+        button.snp.makeConstraints { make in
+            make.centerX.equalTo(self)
+            make.top.equalTo(label).offset(Styles.Sizes.gutter)
         }
     }
 
@@ -32,4 +51,7 @@ final class EmptyView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    @objc private func tapRetry(sender: UIButton) {
+        delegate?.didTapRetry()
+    }
 }


### PR DESCRIPTION
This pr adds the proposed feature from #2214 

When loading fails a "Try Again" button apears right under, tapping this button does the equivelent of "Pulling to Refresh"

**Changes**
- Add "Try Again" button to `EmptyView`
- Add `EmptyViewDelegate` for retry button taps
- Add delegate and show retry button for every class using `EmptyView`

Here's a screenshot
![simulator screen shot - iphone 8 - 2018-10-03 at 18 34 30](https://user-images.githubusercontent.com/732722/46448488-f60f5d00-c73b-11e8-8d8d-f8b13f54bd3d.png)


