### PR TITLE
Order repo branches after fetch

### DIFF
--- a/Classes/Repository/RepositoryBranches/RepositoryBranchesViewController.swift
+++ b/Classes/Repository/RepositoryBranches/RepositoryBranchesViewController.swift
@@ -107,6 +107,6 @@ RepositoryBranchSectionControllerDelegate
     
     func didSelect(value: RepositoryBranchViewModel) {
         self.selectedBranch = value.branch
-        update(animated: true)
+        update(animated: trueUnlessReduceMotionEnabled)
     }
 }

--- a/Classes/Repository/RepositoryBranches/RepositoryBranchesViewController.swift
+++ b/Classes/Repository/RepositoryBranches/RepositoryBranchesViewController.swift
@@ -19,15 +19,18 @@ RepositoryBranchSectionControllerDelegate
     private let repo: String
     private let client: GithubClient
     private var branches: [String] = []
-    public var branch: String
+    private let defaultBranch: String
+    public private(set) var selectedBranch: String
     
-    init(branch: String,
+    init(defaultBranch: String,
+         selectedBranch: String,
          owner: String,
          repo: String,
          client: GithubClient
         )
     {
-        self.branch = branch
+        self.defaultBranch = defaultBranch
+        self.selectedBranch = selectedBranch
         self.owner = owner
         self.repo = repo
         self.client = client
@@ -46,6 +49,23 @@ RepositoryBranchSectionControllerDelegate
         addMenuDoneButton()
     }
     
+    static func arrangeBranches(selectedBranch: String, defaultBranch: String, branches: [String]) -> [String] {
+        var branches = branches
+        
+        if let selectedBranchIndex = branches.index(of: selectedBranch) {
+            let elem = branches.remove(at: selectedBranchIndex)
+            branches.insert(elem, at: 0)
+        }
+        
+        if defaultBranch != selectedBranch,
+            let defaultBranchIndex = branches.index(of: defaultBranch) {
+            let elem = branches.remove(at: defaultBranchIndex)
+            branches.insert(elem, at: 1)
+        }
+        
+        return branches
+    }
+    
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -55,9 +75,15 @@ RepositoryBranchSectionControllerDelegate
                                  repo: repo
             )
         {  [weak self] result in
+            guard let strongSelf = self else { return }
             switch result {
             case .success(let branches):
-                self?.branches = branches
+                self?.branches = RepositoryBranchesViewController.arrangeBranches(
+                    selectedBranch: strongSelf.selectedBranch,
+                    defaultBranch: strongSelf.defaultBranch,
+                    branches: branches
+                )
+                
             case .error:
                 Squawk.showError(message: "Couldn't fetch repository branches")
             }
@@ -69,7 +95,7 @@ RepositoryBranchSectionControllerDelegate
         guard feed.status == .idle else { return [] }
         return branches.map {
             let value = RepositoryBranchViewModel(branch: $0,
-                                                  selected: $0 == self.branch)
+                                                  selected: $0 == self.selectedBranch)
             
             return ListSwiftPair(value) { [weak self] in
                 let controller = RepositoryBranchSectionController()
@@ -80,7 +106,7 @@ RepositoryBranchSectionControllerDelegate
     }
     
     func didSelect(value: RepositoryBranchViewModel) {
-        self.branch = value.branch
-        fetch(page: nil)
+        self.selectedBranch = value.branch
+        update(animated: true)
     }
 }

--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -123,7 +123,8 @@ ContextMenuDelegate {
             guard let strongSelf = self else { return }
             let viewController =
                 RepositoryBranchesViewController(
-                    branch: strongSelf.branch,
+                    defaultBranch: strongSelf.repo.defaultBranch,
+                    selectedBranch: strongSelf.branch,
                     owner: strongSelf.repo.owner,
                     repo: strongSelf.repo.name,
                     client: strongSelf.client
@@ -204,10 +205,10 @@ ContextMenuDelegate {
     
     func contextMenuWillDismiss(viewController: UIViewController, animated: Bool) {
         guard let viewController = viewController as? RepositoryBranchesViewController else { return }
-        self.branch = viewController.branch
+        self.branch = viewController.selectedBranch
         controllers.forEach {
             if let branchUpdatable = $0 as? RepositoryBranchUpdatable {
-                branchUpdatable.updateBranch(to: viewController.branch)
+                branchUpdatable.updateBranch(to: viewController.selectedBranch)
             }
         }
     }

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -446,6 +446,7 @@
 		BDB6AA69215FBC35009BB73C /* RepositoryBranchesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB6AA62215FBC35009BB73C /* RepositoryBranchesViewController.swift */; };
 		BDB6AA6A215FBC35009BB73C /* RepositoryBranchesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB6AA63215FBC35009BB73C /* RepositoryBranchesCell.swift */; };
 		BDB6AA6B215FBC35009BB73C /* GitHubClient+RepositoryBranches.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB6AA64215FBC35009BB73C /* GitHubClient+RepositoryBranches.swift */; };
+		BDB6AA762165B8EA009BB73C /* SwitchBranches.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB6AA752165B8EA009BB73C /* SwitchBranches.swift */; };
 		D8BAD0601FDA0A1A00C41071 /* LabelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BAD05F1FDA0A1A00C41071 /* LabelListCell.swift */; };
 		D8BAD0641FDF221900C41071 /* LabelListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BAD0631FDF221900C41071 /* LabelListView.swift */; };
 		D8BAD0661FDF224600C41071 /* WrappingStaticSpacingFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BAD0651FDF224600C41071 /* WrappingStaticSpacingFlowLayout.swift */; };
@@ -985,6 +986,7 @@
 		BDB6AA62215FBC35009BB73C /* RepositoryBranchesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepositoryBranchesViewController.swift; sourceTree = "<group>"; };
 		BDB6AA63215FBC35009BB73C /* RepositoryBranchesCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepositoryBranchesCell.swift; sourceTree = "<group>"; };
 		BDB6AA64215FBC35009BB73C /* GitHubClient+RepositoryBranches.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GitHubClient+RepositoryBranches.swift"; sourceTree = "<group>"; };
+		BDB6AA752165B8EA009BB73C /* SwitchBranches.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchBranches.swift; sourceTree = "<group>"; };
 		D396E0DA66FED629384A84BC /* Pods_FreetimeWatch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FreetimeWatch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8BAD05F1FDA0A1A00C41071 /* LabelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelListCell.swift; sourceTree = "<group>"; };
 		D8BAD0631FDF221900C41071 /* LabelListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LabelListView.swift; sourceTree = "<group>"; };
@@ -1558,6 +1560,7 @@
 				297AE84E1EC0D58A00B44A1F /* Info.plist */,
 				DC60C6D41F983DF800241271 /* IssueLabelCellTests.swift */,
 				29A476B11ED24D99005D0953 /* IssueTests.swift */,
+				BDB6AA752165B8EA009BB73C /* SwitchBranches.swift */,
 				29C2950D1EC7B43B00D46CD2 /* ListKitTestCase.swift */,
 				29C295091EC7AFA500D46CD2 /* ListTestKit.swift */,
 				2977D8BE215AE12D0073F737 /* LocalNotificationCacheTests.swift */,
@@ -3136,6 +3139,7 @@
 				2986B35F1FD462B300E3CFC6 /* FilePath.swift in Sources */,
 				293A45781F296B7E00DD1006 /* ListTestKit.swift in Sources */,
 				296B4E341F7C80B800C16887 /* GraphQLIDDecodeTests.swift in Sources */,
+				BDB6AA762165B8EA009BB73C /* SwitchBranches.swift in Sources */,
 				DC5C02C71F9C71C400E80B9F /* SearchRecentViewModelTests.swift in Sources */,
 				DC60C6D31F983BB900241271 /* SignatureTests.swift in Sources */,
 				DC60C6D51F983DF800241271 /* IssueLabelCellTests.swift in Sources */,

--- a/FreetimeTests/SwitchBranches.swift
+++ b/FreetimeTests/SwitchBranches.swift
@@ -1,0 +1,42 @@
+//
+//  SwitchBranches.swift
+//  FreetimeTests
+//
+//  Created by B_Litwin on 10/3/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import XCTest
+@testable import Freetime
+
+class SwitchBranches: XCTestCase {
+
+    func test_branchesOrderAfterFetch() {
+        let branches = [
+            "master",
+            "branch_1",
+            "branch_2",
+            "branch_3",
+            "branch_4"
+        ]
+        
+        var output = RepositoryBranchesViewController.arrangeBranches(
+            selectedBranch: "master",
+            defaultBranch: "master",
+            branches: branches
+        )
+        
+        XCTAssertEqual(output[0], "master")
+        XCTAssertEqual(output[1], "branch_1")
+        
+        output = RepositoryBranchesViewController.arrangeBranches(
+            selectedBranch: "branch_2",
+            defaultBranch: "branch_3",
+            branches: branches
+        )
+        
+        XCTAssertEqual(output[0], "branch_2")
+        XCTAssertEqual(output[1], "branch_3")
+    }
+    
+}


### PR DESCRIPTION
#2223 
- added func to order branches + unit tests
- replaced 'var branch: String' w/ 'private(set) var selectedBranch: String'
& added a defaultBranch variable
- changed fetch(page:) to update(animated:) in didSelect(value:) - an oversight from original pr