### PR TITLE
Right align bookmark icon (#1958)

### DIFF
--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -49,6 +49,7 @@ final class IssuesViewController:
         bottom: 2 * Styles.Sizes.rowSpacing + Styles.Sizes.tableCellHeight,
         right: Styles.Sizes.gutter
     )
+    private let bookmarkIconInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
 
     private var needsScrollToBottom = false
     private var lastTimelineElement: ListDiffable?
@@ -198,7 +199,9 @@ final class IssuesViewController:
         messageView.add(contentView: actions)
         
         //show disabled bookmark button until issue has finished loading
-        navigationItem.rightBarButtonItems = [ moreOptionsItem, BookmarkNavigationController.disabledNavigationItem ]
+        let disabledNavItem = BookmarkNavigationController.disabledNavigationItem
+        disabledNavItem.imageInsets = bookmarkIconInset
+        navigationItem.rightBarButtonItems = [ moreOptionsItem, disabledNavItem ]
 
         // insert below so button doesn't appear above autocomplete
         view.insertSubview(manageController.manageButton, belowSubview: messageView)
@@ -261,6 +264,7 @@ final class IssuesViewController:
         guard let rightbarButtonItems = navigationItem.rightBarButtonItems else { return }
         guard let bookmarkItem = rightbarButtonItems.last else { return }
         bookmarkNavController?.configureNavigationItem(bookmarkItem)
+        bookmarkItem.imageInsets = bookmarkIconInset
     }
 
     func viewRepoAction() -> UIAlertAction? {


### PR DESCRIPTION
PR adds a fix for #1958. Adds a left inset of 16 to the bookmark icon. I only changed the inset of the icon on the `IssueViewController`, let me know if it should also be changed in the `RepositoryViewController` or if the inset should be something different

**Disabled Icon**
![simulator screen shot - iphone x - 2018-10-05 at 18 52 03](https://user-images.githubusercontent.com/5355231/46564928-41f30b00-c8d0-11e8-9193-0ea65dd1548a.png)

**Enabled Icon**
![simulator screen shot - iphone x - 2018-10-05 at 18 48 17](https://user-images.githubusercontent.com/5355231/46564931-46b7bf00-c8d0-11e8-8745-c20c602fbe7d.png)
