### PR TITLE
Adds more share actions when browsing a repository (#2161)

### DIFF
--- a/Classes/Issues/Comments/IssueCommentSectionController.swift
+++ b/Classes/Issues/Comments/IssueCommentSectionController.swift
@@ -93,7 +93,7 @@ final class IssueCommentSectionController:
         weak var weakSelf = self
 
         return AlertAction(AlertActionBuilder { $0.rootViewController = weakSelf?.viewController })
-            .share([url], activities: [TUSafariActivity()]) { $0.popoverPresentationController?.sourceView = sender }
+            .share([url], activities: [TUSafariActivity()], type: .shareUrl) { $0.popoverPresentationController?.sourceView = sender }
     }
 
     var deleteAction: UIAlertAction? {

--- a/Classes/Repository/RepositoryCodeBlobViewController.swift
+++ b/Classes/Repository/RepositoryCodeBlobViewController.swift
@@ -20,11 +20,8 @@ final class RepositoryCodeBlobViewController: UIViewController {
     private let feedRefresh = FeedRefresh()
     private let emptyView = EmptyView()
     private var sharingPayload: Any?
-    private var filePath: String {
-        return "\(repo.name)/\(path.path)"
-    }
     private var repoUrl: URL {
-        return URL(string: "https://github.com/\(repo.owner)/\(filePath)")!
+        return URL(string: "https://github.com/\(repo.owner)/\(repo.name)/blob/\(branch)/\(path.path)")!
     }
 
     private lazy var moreOptionsItem: UIBarButtonItem = {
@@ -110,7 +107,7 @@ final class RepositoryCodeBlobViewController: UIViewController {
         weak var weakSelf = self
         let alertBuilder = AlertActionBuilder { $0.rootViewController = weakSelf }
         var actions = [
-            AlertAction(alertBuilder).share([self.filePath], activities: nil, type: .shareFilePath) {
+            AlertAction(alertBuilder).share([path.path], activities: nil, type: .shareFilePath) {
                 $0.popoverPresentationController?.setSourceView(sender)
             },
             AlertAction(alertBuilder).share([repoUrl], activities: [TUSafariActivity()], type: .shareUrl) {

--- a/Classes/Repository/RepositoryCodeDirectoryViewController.swift
+++ b/Classes/Repository/RepositoryCodeDirectoryViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import IGListKit
+import TUSafariActivity
 
 final class RepositoryCodeDirectoryViewController: BaseListViewController<NSNumber>,
 BaseListViewControllerDataSource,
@@ -20,6 +21,21 @@ RepositoryBranchUpdatable
     private let path: FilePath
     private let repo: RepositoryDetails
     private var files = [RepositoryFile]()
+    private var filePath: String {
+        return "\(repo.name)/\(path.path)"
+    }
+    private var repoUrl: URL {
+        return URL(string: "https://github.com/\(repo.owner)/\(filePath)")!
+    }
+    private lazy var moreOptionsItem: UIBarButtonItem = {
+        let barButtonItem = UIBarButtonItem(
+            image: UIImage(named: "bullets-hollow"),
+            target: self,
+            action: #selector(RepositoryCodeDirectoryViewController.onShare(sender:)))
+        barButtonItem.isEnabled = false
+
+        return barButtonItem
+    }()
 
     init(
         client: GithubClient,
@@ -50,6 +66,7 @@ RepositoryBranchUpdatable
         super.viewDidLoad()
         configureTitle(filePath: path, target: self, action: #selector(onFileNavigationTitle(sender:)))
         makeBackBarItemEmpty()
+        navigationItem.rightBarButtonItem = moreOptionsItem
     }
 
     // MARK: Public API
@@ -73,6 +90,33 @@ RepositoryBranchUpdatable
         showAlert(filePath: path, sender: sender)
     }
 
+    @objc func onShare(sender: UIButton) {
+        let alertTitle = "\(repo.owner)/\(repo.name):\(branch)"
+        let alert = UIAlertController.configured(title: alertTitle, preferredStyle: .actionSheet)
+        
+        weak var weakSelf = self
+        let alertBuilder = AlertActionBuilder { $0.rootViewController = weakSelf }
+        var actions = [
+            AlertAction(alertBuilder).share([self.filePath], activities: nil, type: .shareFilePath) {
+                $0.popoverPresentationController?.setSourceView(sender)
+            },
+            AlertAction(alertBuilder).share([repoUrl], activities: [TUSafariActivity()], type: .shareUrl) {
+                $0.popoverPresentationController?.setSourceView(sender)
+            },
+            AlertAction.cancel()
+        ]
+        
+        if let name = self.path.components.last {
+            actions.insert(AlertAction(alertBuilder).share([name], activities: nil, type: .shareFileName) {
+                $0.popoverPresentationController?.setSourceView(sender)
+            }, at: 1)
+        }
+
+        alert.addActions(actions)
+        alert.popoverPresentationController?.setSourceView(sender)
+        present(alert, animated: trueUnlessReduceMotionEnabled)
+    }
+
     // MARK: Overrides
 
     override func fetch(page: NSNumber?) {
@@ -88,6 +132,7 @@ RepositoryBranchUpdatable
             case .success(let files):
                 self?.files = files
                 self?.update(animated: trueUnlessReduceMotionEnabled)
+                self?.moreOptionsItem.isEnabled = true
             }
         }
     }

--- a/Classes/Repository/RepositoryCodeDirectoryViewController.swift
+++ b/Classes/Repository/RepositoryCodeDirectoryViewController.swift
@@ -21,11 +21,8 @@ RepositoryBranchUpdatable
     private let path: FilePath
     private let repo: RepositoryDetails
     private var files = [RepositoryFile]()
-    private var filePath: String {
-        return "\(repo.name)/\(path.path)"
-    }
     private var repoUrl: URL {
-        return URL(string: "https://github.com/\(repo.owner)/\(filePath)")!
+        return URL(string: "https://github.com/\(repo.owner)/\(repo.name)/tree/\(branch)/\(path.path)")!
     }
     private lazy var moreOptionsItem: UIBarButtonItem = {
         let barButtonItem = UIBarButtonItem(
@@ -97,7 +94,7 @@ RepositoryBranchUpdatable
         weak var weakSelf = self
         let alertBuilder = AlertActionBuilder { $0.rootViewController = weakSelf }
         var actions = [
-            AlertAction(alertBuilder).share([self.filePath], activities: nil, type: .shareFilePath) {
+            AlertAction(alertBuilder).share([path.path], activities: nil, type: .shareFilePath) {
                 $0.popoverPresentationController?.setSourceView(sender)
             },
             AlertAction(alertBuilder).share([repoUrl], activities: [TUSafariActivity()], type: .shareUrl) {

--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -169,7 +169,7 @@ ContextMenuDelegate {
 
         alert.addActions([
             repo.hasIssuesEnabled ? newIssueAction() : nil,
-            AlertAction(alertBuilder).share([repoUrl], activities: [TUSafariActivity()]) {
+            AlertAction(alertBuilder).share([repoUrl], activities: [TUSafariActivity()], type: .shareUrl) {
                 $0.popoverPresentationController?.setSourceView(sender)
             },
             switchBranchAction(),

--- a/Classes/Utility/AlertAction.swift
+++ b/Classes/Utility/AlertAction.swift
@@ -21,6 +21,24 @@ struct AlertAction {
     let title: String?
     let style: UIAlertActionStyle
 
+    enum AlertShareType {
+        case shareUrl
+        case shareContent
+        case shareFilePath
+        case shareFileName
+        case `default`
+
+        var localizedString: String {
+            switch self {
+            case .shareUrl: return NSLocalizedString("Share URL", comment: "")
+            case .shareContent: return NSLocalizedString("Share Content", comment: "")
+            case .shareFilePath: return NSLocalizedString("Copy Path", comment: "")
+            case .shareFileName: return NSLocalizedString("Copy Name", comment: "")
+            default: return NSLocalizedString("Share", comment: "")
+            }
+        }
+    }
+
     // MARK: Init
 
     init(_ builder: AlertActionBuilder) {
@@ -37,8 +55,9 @@ struct AlertAction {
 
     func share(_ items: [Any],
                activities: [UIActivity]?,
+               type: AlertShareType = .default,
                buildActivityBlock: ((UIActivityViewController) -> Void)?) -> UIAlertAction {
-        return UIAlertAction(title: NSLocalizedString("Share", comment: ""), style: .default) { _ in
+        return UIAlertAction(title: type.localizedString, style: .default) { _ in
             let activityController = UIActivityViewController(activityItems: items, applicationActivities: activities)
             buildActivityBlock?(activityController)
             self.rootViewController?.present(activityController, animated: trueUnlessReduceMotionEnabled)


### PR DESCRIPTION
Adds in the feature for more share options when browsing a repository (#2161)
- Adds the `...` when viewing a directory
- Changes the share button to `...` when viewing a file
- Adds "Copy Path", "Copy Name", "Share URL", and "Share Content" options
- each option will open the share sheet giving you the option to share with a different app or just copy it to the clipboard.

For a file `Classes/Issues/Files/IssueFileCell.swift`
- Copy path: `Classes/Issues/Files/IssueFileCell.swift`
- Copy name: `IssueFileCell.swift`
- Share URL: `https://github.com/GitHawkApp/GitHawk/blob/master/Classes/Issues/Files/IssueFileCell.swift`

For a directory `Classes/Issues/Files`
- Copy path: `Classes/Issues/Files`
- Copy Name: `Files`
- Share URL: `https://github.com/GitHawkApp/GitHawk/tree/master/Classes/Issues/Files`

![simulator screen shot - iphone 8 - 2018-10-06 at 12 00 54](https://user-images.githubusercontent.com/5355231/46573780-a4dfb300-c95f-11e8-9c4d-b9aef756b83c.png) ![simulator screen shot - iphone 8 - 2018-10-06 at 12 00 58](https://user-images.githubusercontent.com/5355231/46573781-a4dfb300-c95f-11e8-807b-e42ad00395dc.png)


