### PR TITLE
Fixes settings write review indent

### DIFF
--- a/Classes/Settings/Settings.storyboard
+++ b/Classes/Settings/Settings.storyboard
@@ -348,10 +348,10 @@
                                                 </imageView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="guA-My-iRb" firstAttribute="leading" secondItem="uAb-lB-GZA" secondAttribute="leadingMargin" id="F9S-kd-38Z"/>
                                                 <constraint firstItem="guA-My-iRb" firstAttribute="centerY" secondItem="uAb-lB-GZA" secondAttribute="centerY" id="Lmv-Cf-s8i"/>
                                                 <constraint firstItem="l9s-bQ-bad" firstAttribute="centerY" secondItem="uAb-lB-GZA" secondAttribute="centerY" id="WGF-E7-3TC"/>
                                                 <constraint firstAttribute="trailing" secondItem="l9s-bQ-bad" secondAttribute="trailing" constant="15" id="hbT-TO-kjD"/>
+                                                <constraint firstItem="guA-My-iRb" firstAttribute="leading" secondItem="uAb-lB-GZA" secondAttribute="leading" constant="16" id="vk2-fv-yD3"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <inset key="separatorInset" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>


### PR DESCRIPTION
Fixes #2190 

Looks like "constraint to margin" is messing up on new iPhones. 

After the fix on iPhone XR

<img width="500" alt="screenshot 2018-10-08 at 10 58 28 am" src="https://user-images.githubusercontent.com/12063704/46593495-16e40380-caea-11e8-9ad5-aa4e0e1bc915.png">