### PR TITLE
Always call completion block when early returning b/c of bg

### DIFF
--- a/Classes/Notifications/NotificationModelController.swift
+++ b/Classes/Notifications/NotificationModelController.swift
@@ -52,7 +52,11 @@ final class NotificationModelController {
         completion: @escaping (Result<([NotificationViewModel], Int?)>) -> Void
         ) {
         // hack to prevent double-fetching notifications when awaking from bg fetch
-        guard UIApplication.shared.applicationState != .background else { return }
+        guard UIApplication.shared.applicationState != .background else {
+            // return success to avoid error states
+            completion(.success(([], nil)))
+            return
+        }
 
         let badge = githubClient.badge
         let contentSizeCategory = UIContentSizeCategory.preferred

--- a/Classes/View Controllers/SplitViewControllerDelegate.swift
+++ b/Classes/View Controllers/SplitViewControllerDelegate.swift
@@ -31,10 +31,15 @@ final class SplitViewControllerDelegate: UISplitViewControllerDelegate {
             let primaryNav = tab.selectedViewController as? UINavigationController,
             let secondaryNav = secondaryViewController as? UINavigationController {
 
-            // remove any placeholder VCs from the stack
-            primaryNav.viewControllers += secondaryNav.viewControllers.filter {
+            let collapsedControllers = secondaryNav.viewControllers.filter {
                 $0.hidesBottomBarWhenPushed = true
+                // remove any placeholder VCs from the stack
                 return ($0 is SplitPlaceholderViewController) == false
+            }
+            // avoid setting view controllers b/c can result in viewDidLoad being called
+            // https://github.com/GitHawkApp/GitHawk/issues/2230
+            if collapsedControllers.count > 0 {
+                primaryNav.viewControllers += collapsedControllers
             }
         }
 


### PR DESCRIPTION
Hack fix for #2230 

The infinite spinner occurs b/c the completion block is never called. I can't reproduce this issue but can at least follow the bug. There might be some other weird UI behaviors that come out of this, we can fix that once we see what they are.