### PR TITLE
Fixes navigation controller on "View Source" from settings

### DIFF
--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -183,7 +183,8 @@ NewIssueTableViewControllerDelegate {
             hasIssuesEnabled: true
         )
         let repoViewController = RepositoryViewController(client: client, repo: repo)
-        navigationController?.showDetailViewController(repoViewController, sender: self)
+        let navController = UINavigationController(rootViewController: repoViewController)
+        showDetailViewController(navController, sender: self)
     }
   
     func onSetDefaultReaction() {


### PR DESCRIPTION
Fixes #2252 

Since we don't have navigation controller (on cold start), view source on settings opens Repo View Controller without a navigation controller. 😦 

But it will work fine if we have a nav controller in our stack. optional was helping us from crashing the app so far. I guess in a long run we might need to think in terms of moving to **Coordinators** for managing navigation inside the app to avoid issues like this. (probably better support for iPad and iPhone landscape)