### PR TITLE
Reduce bottom inset when manage button hidden

### DIFF
--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -44,13 +44,16 @@ final class IssuesViewController:
     private var bookmarkNavController: BookmarkNavigationController? = nil
     private var autocompleteController: AutocompleteController!
     private let manageController: IssueManagingContextController
-    private let threadInset = UIEdgeInsets(
-        top: Styles.Sizes.rowSpacing / 2,
-        left: Styles.Sizes.gutter,
-        bottom: 2 * Styles.Sizes.rowSpacing + Styles.Sizes.tableCellHeight,
-        right: Styles.Sizes.gutter
-    )
-
+    private var threadInset: UIEdgeInsets {
+        let insetForManageButton = manageController.manageButton.isHidden ? 0 : Styles.Sizes.tableCellHeight
+        return UIEdgeInsets(
+            top: Styles.Sizes.rowSpacing / 2,
+            left: Styles.Sizes.gutter,
+            bottom: 2 * Styles.Sizes.rowSpacing + insetForManageButton,
+            right: Styles.Sizes.gutter
+        )
+    }
+    
     private var needsScrollToBottom = false
     private var lastTimelineElement: ListDiffable?
     private var actions: IssueTextActionsView?
@@ -238,6 +241,9 @@ final class IssuesViewController:
                 y: messageView.frame.minY - manageButtonSize.height - Styles.Sizes.gutter),
             size: manageButtonSize
         )
+
+        // Recalculate the bottom content inset since the manageButton‘s visibility may have changed.
+        feed.collectionView.contentInset.bottom = threadInset.bottom
     }
 
     // MARK: Private API


### PR DESCRIPTION
## What This Does

This fixes #2229. Before this fix, the bottom inset for the collection view was the same whether or not the manage button was visible. After this fix, the bottom inset is smaller when the manage button is hidden.

**Before**
![before](https://user-images.githubusercontent.com/5342778/46928520-f1cf2380-d008-11e8-8b98-3b45c638196d.png)

**After**
![after](https://user-images.githubusercontent.com/5342778/46928532-07444d80-d009-11e8-8495-577c91cd6577.png)

## How to Test

1. Visit an issue where the manage button is hidden.
    1. Once loaded, confirm that the inset and all other views appear correctly.
    2. Rotate the device. Confirm that the inset and all other views appear correctly.
    3. Pull to refresh. Confirm that the inset and that all other views appear correctly.
2. Repeat the above for an issue where the manage button is visible.