### PR TITLE
Search for labels in-app 

### DIFF
--- a/Classes/Issues/GithubClient+Issues.swift
+++ b/Classes/Issues/GithubClient+Issues.swift
@@ -86,6 +86,7 @@ extension GithubClient {
                     )
 
                     let timeline = issueType.timelineViewModels(
+                        client: self,
                         owner: owner,
                         repo: repo,
                         contentSizeCategory: contentSizeCategory,
@@ -354,6 +355,7 @@ extension GithubClient {
         for newLabel in labels {
             if !oldLabelNames.contains(newLabel.name) {
                 newEvents.append(IssueLabeledModel(
+                    client: self,
                     id: UUID().uuidString,
                     actor: actor,
                     title: newLabel.name,
@@ -370,6 +372,7 @@ extension GithubClient {
         for oldLabel in previous.labels.labels {
             if !newLabelNames.contains(oldLabel.name) {
                 newEvents.append(IssueLabeledModel(
+                    client: self, 
                     id: UUID().uuidString,
                     actor: actor,
                     title: oldLabel.name,

--- a/Classes/Issues/Issue+IssueType.swift
+++ b/Classes/Issues/Issue+IssueType.swift
@@ -64,6 +64,7 @@ extension IssueOrPullRequestQuery.Data.Repository.IssueOrPullRequest.AsIssue: Is
     }
 
     func timelineViewModels(
+        client: GithubClient,
         owner: String,
         repo: String,
         contentSizeCategory: UIContentSizeCategory,
@@ -100,6 +101,7 @@ extension IssueOrPullRequestQuery.Data.Repository.IssueOrPullRequest.AsIssue: Is
             } else if let unlabeled = node.asUnlabeledEvent,
                 let date = unlabeled.createdAt.githubDate {
                 let model = IssueLabeledModel(
+                    client: client,
                     id: unlabeled.fragments.nodeFields.id,
                     actor: unlabeled.actor?.login ?? Constants.Strings.unknown,
                     title: unlabeled.label.name,
@@ -115,6 +117,7 @@ extension IssueOrPullRequestQuery.Data.Repository.IssueOrPullRequest.AsIssue: Is
             } else if let labeled = node.asLabeledEvent,
                 let date = labeled.createdAt.githubDate {
                 let model = IssueLabeledModel(
+                    client: client,
                     id: labeled.fragments.nodeFields.id,
                     actor: labeled.actor?.login ?? Constants.Strings.unknown,
                     title: labeled.label.name,

--- a/Classes/Issues/IssueType.swift
+++ b/Classes/Issues/IssueType.swift
@@ -39,6 +39,7 @@ protocol IssueType {
     func mergeModel(availableTypes: [IssueMergeType]) -> IssueMergeModel?
 
     func timelineViewModels(
+        client: GithubClient,
         owner: String,
         repo: String,
         contentSizeCategory: UIContentSizeCategory,

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -451,7 +451,7 @@ final class IssuesViewController: MessageViewController,
         switch object {
         // header and metadata
         case is IssueTitleModel: return IssueTitleSectionController()
-        case is IssueLabelsModel: return IssueLabelsSectionController(issue: model)
+        case is IssueLabelsModel: return IssueLabelsSectionController(client: client, issue: model)
         case is IssueAssigneesModel: return IssueAssigneesSectionController()
         case is Milestone: return IssueMilestoneSectionController(issueModel: model)
         case is IssueFileChangesModel: return IssueViewFilesSectionController(issueModel: model, client: client)

--- a/Classes/Issues/Labeled/IssueLabeledModel.swift
+++ b/Classes/Issues/Labeled/IssueLabeledModel.swift
@@ -27,6 +27,7 @@ final class IssueLabeledModel: ListDiffable {
     let string: StyledTextRenderer
 
     init(
+        client: GithubClient,
         id: String,
         actor: String,
         title: String,
@@ -68,7 +69,7 @@ final class IssueLabeledModel: ListDiffable {
                 .backgroundColor: labelColor,
                 .foregroundColor: labelColor.textOverlayColor ?? .black,
                 .baselineOffset: 1, // offset for better rounded background colors
-                MarkdownAttribute.label: LabelDetails(owner: repoOwner, repo: repoName, label: title)
+                MarkdownAttribute.label: LabelDetails(client: client, owner: repoOwner, repo: repoName, label: title)
                 ]
             )))
             .restore()

--- a/Classes/Issues/Labels/IssueLabelsSectionController.swift
+++ b/Classes/Issues/Labels/IssueLabelsSectionController.swift
@@ -19,7 +19,7 @@ ListBindingSectionControllerSelectionDelegate {
     private var sizeCache = [String: CGSize]()
     private let lockedModel = Constants.Strings.locked
 
-    init(client: GitHubClient, issue: IssueDetailsModel) {
+    init(client: GithubClient, issue: IssueDetailsModel) {
         self.client = client
         self.issue = issue
         super.init()
@@ -100,7 +100,14 @@ ListBindingSectionControllerSelectionDelegate {
 
     func sectionController(_ sectionController: ListBindingSectionController<ListDiffable>, didSelectItemAt index: Int, viewModel: Any) {
         guard let viewModel = viewModel as? RepositoryLabel else { return }
-        viewController?.presentLabels(owner: issue.owner, repo: issue.repo, label: viewModel.name)
+        viewController?.presentLabels(
+            label: LabelDetails(
+                client: client,
+                owner: issue.owner,
+                repo: issue.repo,
+                label: viewModel.name
+            )
+        )
     }
 
 }

--- a/Classes/Issues/Labels/IssueLabelsSectionController.swift
+++ b/Classes/Issues/Labels/IssueLabelsSectionController.swift
@@ -7,17 +7,20 @@
 //
 
 import UIKit
+import GitHubAPI
 import IGListKit
 
 final class IssueLabelsSectionController: ListBindingSectionController<IssueLabelsModel>,
 ListBindingSectionControllerDataSource,
 ListBindingSectionControllerSelectionDelegate {
-
+    
+    private let client: GithubClient
     private let issue: IssueDetailsModel
     private var sizeCache = [String: CGSize]()
     private let lockedModel = Constants.Strings.locked
 
-    init(issue: IssueDetailsModel) {
+    init(client: GitHubClient, issue: IssueDetailsModel) {
+        self.client = client
         self.issue = issue
         super.init()
         minimumInteritemSpacing = Styles.Sizes.labelSpacing

--- a/Classes/Issues/PullRequest+IssueType.swift
+++ b/Classes/Issues/PullRequest+IssueType.swift
@@ -95,6 +95,7 @@ extension IssueOrPullRequestQuery.Data.Repository.IssueOrPullRequest.AsPullReque
     }
 
     func timelineViewModels(
+        client: GithubClient,
         owner: String,
         repo: String,
         contentSizeCategory: UIContentSizeCategory,
@@ -131,6 +132,7 @@ extension IssueOrPullRequestQuery.Data.Repository.IssueOrPullRequest.AsPullReque
             } else if let unlabeled = node.asUnlabeledEvent,
                 let date = unlabeled.createdAt.githubDate {
                 let model = IssueLabeledModel(
+                    client: client,
                     id: unlabeled.fragments.nodeFields.id,
                     actor: unlabeled.actor?.login ?? Constants.Strings.unknown,
                     title: unlabeled.label.name,
@@ -146,6 +148,7 @@ extension IssueOrPullRequestQuery.Data.Repository.IssueOrPullRequest.AsPullReque
             } else if let labeled = node.asLabeledEvent,
                 let date = labeled.createdAt.githubDate {
                 let model = IssueLabeledModel(
+                    client: client, 
                     id: labeled.fragments.nodeFields.id,
                     actor: labeled.actor?.login ?? Constants.Strings.unknown,
                     title: labeled.label.name,

--- a/Classes/Models/LabelDetails.swift
+++ b/Classes/Models/LabelDetails.swift
@@ -10,11 +10,13 @@ import Foundation
 
 final class LabelDetails {
 
+    let client: GithubClient
     let owner: String
     let repo: String
     let label: String
 
-    init(owner: String, repo: String, label: String) {
+    init(client: GithubClient, owner: String, repo: String, label: String) {
+        self.client = client
         self.owner = owner
         self.repo = repo
         self.label = label

--- a/Classes/Repository/RepositoryIssuesViewController.swift
+++ b/Classes/Repository/RepositoryIssuesViewController.swift
@@ -19,16 +19,18 @@ BaseListViewControllerDataSource,
 SearchBarSectionControllerDelegate {
 
     private var models = [ListDiffable]()
-    private let repo: RepositoryDetails
+    private let owner: String
+    private let repo: String
     private let client: RepositoryClient
     private let type: RepositoryIssuesType
     private let searchKey: ListDiffable = "searchKey" as ListDiffable
     private let debouncer = Debouncer()
     private var previousSearchString = "is:open "
 
-    init(client: GithubClient, repo: RepositoryDetails, type: RepositoryIssuesType) {
+    init(client: GithubClient, owner: String, repo: String, type: RepositoryIssuesType) {
+        self.owner = owner
         self.repo = repo
-        self.client = RepositoryClient(githubClient: client, owner: repo.owner, name: repo.name)
+        self.client = RepositoryClient(githubClient: client, owner: owner, name: repo)
         self.type = type
 
         super.init(
@@ -105,7 +107,7 @@ SearchBarSectionControllerDelegate {
                 query: previousSearchString
             )
         }
-        return RepositorySummarySectionController(client: client.githubClient, repo: repo)
+        return RepositorySummarySectionController(client: client.githubClient, owner: owner, repo: repo)
     }
 
     func emptySectionController(listAdapter: ListAdapter) -> ListSectionController {
@@ -129,7 +131,7 @@ SearchBarSectionControllerDelegate {
         case .issues: typeQuery = "is:issue"
         case .pullRequests: typeQuery = "is:pr"
         }
-        return "repo:\(repo.owner)/\(repo.name) \(typeQuery) \(previousSearchString)"
+        return "repo:\(owner)/\(repo) \(typeQuery) \(previousSearchString)"
     }
 
 }

--- a/Classes/Repository/RepositoryIssuesViewController.swift
+++ b/Classes/Repository/RepositoryIssuesViewController.swift
@@ -26,12 +26,17 @@ SearchBarSectionControllerDelegate {
     private let searchKey: ListDiffable = "searchKey" as ListDiffable
     private let debouncer = Debouncer()
     private var previousSearchString = "is:open "
+    private let label: String?
 
-    init(client: GithubClient, owner: String, repo: String, type: RepositoryIssuesType) {
+    init(client: GithubClient, owner: String, repo: String, type: RepositoryIssuesType, label: String? = nil) {
         self.owner = owner
         self.repo = repo
         self.client = RepositoryClient(githubClient: client, owner: owner, name: repo)
         self.type = type
+        self.label = label
+        if let label = label {
+            previousSearchString += "label:\(label) "
+        }
 
         super.init(
             emptyErrorMessage: NSLocalizedString("Cannot load issues.", comment: "")
@@ -53,10 +58,12 @@ SearchBarSectionControllerDelegate {
         super.viewDidLoad()
 
         makeBackBarItemEmpty()
-
+        
+        if label == nil {
         // set the frame in -viewDidLoad is required when working with TabMan
-        feed.collectionView.frame = view.bounds
-        feed.collectionView.contentInsetAdjustmentBehavior = .never
+            feed.collectionView.frame = view.bounds
+            feed.collectionView.contentInsetAdjustmentBehavior = .never
+        }
     }
 
     // MARK: Overrides

--- a/Classes/Repository/RepositorySummarySectionController.swift
+++ b/Classes/Repository/RepositorySummarySectionController.swift
@@ -11,9 +11,11 @@ import IGListKit
 final class RepositorySummarySectionController: ListGenericSectionController<RepositoryIssueSummaryModel> {
 
     private let client: GithubClient
-    private let repo: RepositoryDetails
+    private let owner: String
+    private let repo: String
 
-    init(client: GithubClient, repo: RepositoryDetails) {
+    init(client: GithubClient, owner: String, repo: String) {
+        self.owner = owner
         self.client = client
         self.repo = repo
         super.init()
@@ -53,7 +55,7 @@ final class RepositorySummarySectionController: ListGenericSectionController<Rep
 
     override func didSelectItem(at index: Int) {
         guard let number = self.object?.number else { return }
-        let issueModel = IssueDetailsModel(owner: repo.owner, repo: repo.name, number: number)
+        let issueModel = IssueDetailsModel(owner: owner, repo: repo, number: number)
         let controller = IssuesViewController(client: client, model: issueModel)
         viewController?.view.endEditing(false) // resign keyboard if it was triggered to become active by SearchBar 
         viewController?.navigationController?.pushViewController(controller, animated: trueUnlessReduceMotionEnabled)

--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -47,10 +47,10 @@ ContextMenuDelegate {
 
         var controllers: [UIViewController] = [RepositoryOverviewViewController(client: client, repo: repo)]
         if repo.hasIssuesEnabled {
-            controllers.append(RepositoryIssuesViewController(client: client, repo: repo, type: .issues))
+            controllers.append(RepositoryIssuesViewController(client: client, owner: repo.owner, repo: repo.name, type: .issues))
         }
         controllers += [
-            RepositoryIssuesViewController(client: client, repo: repo, type: .pullRequests),
+            RepositoryIssuesViewController(client: client, owner: repo.owner, repo: repo.name, type: .pullRequests),
             RepositoryCodeDirectoryViewController.createRoot(client: client, repo: repo, branch: repo.defaultBranch)
         ]
         self.controllers = controllers

--- a/Classes/Utility/UIViewController+Routing.swift
+++ b/Classes/Utility/UIViewController+Routing.swift
@@ -19,7 +19,7 @@ extension UIViewController {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             }
         case .username(let username): presentProfile(login: username)
-        case .label(let label): presentLabels(owner: label.owner, repo: label.repo, label: label.label)
+        case .label(let label): presentLabels(label: label)
         case .commit(let commit): presentCommit(owner: commit.owner, repo: commit.repo, hash: commit.hash)
         default: return false
         }

--- a/Classes/View Controllers/UIViewController+PresentLabels.swift
+++ b/Classes/View Controllers/UIViewController+PresentLabels.swift
@@ -1,0 +1,26 @@
+//
+//  UIViewController+PresentLabels.swift
+//  Freetime
+//
+//  Created by B_Litwin on 10/17/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+    func presentLabels(label: LabelDetails) {
+        let repositoryIssuesViewController =
+            RepositoryIssuesViewController(
+                client: label.client,
+                owner: label.owner,
+                repo: label.repo,
+                type: .issues
+        )
+        
+        navigationController?.pushViewController(
+            repositoryIssuesViewController,
+            animated: true
+        )
+    }
+}

--- a/Classes/View Controllers/UIViewController+PresentLabels.swift
+++ b/Classes/View Controllers/UIViewController+PresentLabels.swift
@@ -15,8 +15,9 @@ extension UIViewController {
                 client: label.client,
                 owner: label.owner,
                 repo: label.repo,
-                type: .issues
-        )
+                type: .issues,
+                label: label.label
+            )
         
         navigationController?.pushViewController(
             repositoryIssuesViewController,

--- a/Classes/View Controllers/UIViewController+Safari.swift
+++ b/Classes/View Controllers/UIViewController+Safari.swift
@@ -30,11 +30,6 @@ extension UIViewController {
         presentSafari(url: url)
     }
 
-    func presentLabels(owner: String, repo: String, label: String) {
-        guard let url = URL(string: "https://github.com/\(owner)/\(repo)/labels/\(label)") else { return }
-        presentSafari(url: url)
-    }
-
     func presentMilestone(owner: String, repo: String, milestone: Int) {
         guard let url = URL(string: "https://github.com/\(owner)/\(repo)/milestone/\(milestone)") else { return }
         presentSafari(url: url)


### PR DESCRIPTION
Connected to #2263

In most files, the changes are adding a `GithubClient` parameter so that it can be passed to the `LabelDetails` model, which is passed along to init and present a `RepositoryIssuesViewController`. 

Also, I removed the [RepositoryDetails](https://github.com/GitHawkApp/GitHawk/blob/master/Classes/Repository/RepositoryDetails.swift) parameter from the `RepositoryIssuesViewController` initializer and replaced it with `owner` and `name`. This was so that we didn't have to pass around a reference to `RepositoryDetails` as well, and also because we were only using the `name` and `owner` fields of `RepositoryDetails` anyway. 

### vid:

![ezgif com-optimize](https://user-images.githubusercontent.com/26695477/47126399-68149580-d256-11e8-96f0-960c26e17e85.gif)

<br></br> 

I've checked manually that it works when labels are embedded in other contexts as well. Only place it doesn't work is on the main RepoIssuesSectionController list, which as @Huddie suggested, we should enable as well. 