### PR TITLE
Search for labels in app (take two)

### DIFF
--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -34,7 +34,9 @@ final class IssuesViewController: MessageViewController,
     IssueCommentSectionControllerDelegate,
     IssueTextActionsViewSendDelegate,
     EmptyViewDelegate,
-    MessageTextViewListener {
+    MessageTextViewListener,
+    IssueLabelTapSectionControllerDelegate
+{
 
     private let client: GithubClient
     private let model: IssueDetailsModel
@@ -451,7 +453,7 @@ final class IssuesViewController: MessageViewController,
         switch object {
         // header and metadata
         case is IssueTitleModel: return IssueTitleSectionController()
-        case is IssueLabelsModel: return IssueLabelsSectionController(issue: model)
+        case is IssueLabelsModel: return IssueLabelsSectionController(issue: model, tapDelegate: self)
         case is IssueAssigneesModel: return IssueAssigneesSectionController()
         case is Milestone: return IssueMilestoneSectionController(issueModel: model)
         case is IssueFileChangesModel: return IssueViewFilesSectionController(issueModel: model, client: client)
@@ -465,7 +467,7 @@ final class IssuesViewController: MessageViewController,
                 autocomplete: autocompleteController.autocomplete.copy,
                 issueCommentDelegate: self
             )
-        case is IssueLabeledModel: return IssueLabeledSectionController(issueModel: model)
+        case is IssueLabeledModel: return IssueLabeledSectionController(issueModel: model, tapDelegate: self)
         case is IssueStatusEventModel: return IssueStatusEventSectionController(issueModel: model)
         case is IssueReferencedModel: return IssueReferencedSectionController(client: client)
         case is IssueReferencedCommitModel: return IssueReferencedCommitSectionController()
@@ -631,5 +633,11 @@ final class IssuesViewController: MessageViewController,
 
     func didChangeSelection(textView: MessageTextView) {}
     func willChangeRange(textView: MessageTextView, to range: NSRange) {}
+    
+    // MARK: IssueLabelsSectionControllerDelegate
+    
+    func didTapLabel(owner: String, repo: String, label: String) {
+        print("Label tapped! \(owner) \(repo) \(label)" )
+    }
 
 }

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -636,8 +636,8 @@ final class IssuesViewController: MessageViewController,
     
     // MARK: IssueLabelsSectionControllerDelegate
     
-    func didTapLabel(owner: String, repo: String, label: String) {
-        print("Label tapped! \(owner) \(repo) \(label)" )
+    func didTapIssueLabel(owner: String, repo: String, label: String) {
+        presentLabels(client: client, owner: owner, repo: repo, label: label)
     }
 
 }

--- a/Classes/Issues/Labeled/IssueLabeledSectionController.swift
+++ b/Classes/Issues/Labeled/IssueLabeledSectionController.swift
@@ -38,7 +38,7 @@ final class IssueLabeledSectionController: ListGenericSectionController<IssueLab
     
     func didTap(cell: MarkdownStyledTextView, attribute: DetectedMarkdownAttribute) {
         guard case .label(let label) = attribute else { return }
-        tapDelegate?.didTapLabel(owner: label.owner, repo: label.repo, label: label.label)
+        tapDelegate?.didTapIssueLabel(owner: label.owner, repo: label.repo, label: label.label)
     }
     
 }

--- a/Classes/Issues/Labeled/IssueLabeledSectionController.swift
+++ b/Classes/Issues/Labeled/IssueLabeledSectionController.swift
@@ -18,8 +18,8 @@ final class IssueLabeledSectionController: ListGenericSectionController<IssueLab
 
     init(issueModel: IssueDetailsModel, tapDelegate: IssueLabelTapSectionControllerDelegate) {
         self.issueModel = issueModel
-        super.init()
         self.tapDelegate = tapDelegate
+        super.init()
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
@@ -37,8 +37,11 @@ final class IssueLabeledSectionController: ListGenericSectionController<IssueLab
     }
     
     func didTap(cell: MarkdownStyledTextView, attribute: DetectedMarkdownAttribute) {
-        guard case .label(let label) = attribute else { return }
-        tapDelegate?.didTapIssueLabel(owner: label.owner, repo: label.repo, label: label.label)
+        if case .label(let label) = attribute {
+            tapDelegate?.didTapIssueLabel(owner: label.owner, repo: label.repo, label: label.label)
+        } else {
+            viewController?.handle(attribute: attribute)
+        }
     }
     
 }

--- a/Classes/Issues/Labeled/IssueLabeledSectionController.swift
+++ b/Classes/Issues/Labeled/IssueLabeledSectionController.swift
@@ -9,13 +9,17 @@
 import Foundation
 import IGListKit
 
-final class IssueLabeledSectionController: ListGenericSectionController<IssueLabeledModel> {
+
+
+final class IssueLabeledSectionController: ListGenericSectionController<IssueLabeledModel>, MarkdownStyledTextViewDelegate {
 
     private let issueModel: IssueDetailsModel
+    private weak var tapDelegate: IssueLabelTapSectionControllerDelegate?
 
-    init(issueModel: IssueDetailsModel) {
+    init(issueModel: IssueDetailsModel, tapDelegate: IssueLabelTapSectionControllerDelegate) {
         self.issueModel = issueModel
         super.init()
+        self.tapDelegate = tapDelegate
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
@@ -28,8 +32,13 @@ final class IssueLabeledSectionController: ListGenericSectionController<IssueLab
             let object = self.object
             else { fatalError("Missing collection context, cell incorrect type, or object missing") }
         cell.configure(object)
-        cell.delegate = viewController
+        cell.delegate = self
         return cell
     }
-
+    
+    func didTap(cell: MarkdownStyledTextView, attribute: DetectedMarkdownAttribute) {
+        guard case .label(let label) = attribute else { return }
+        tapDelegate?.didTapLabel(owner: label.owner, repo: label.repo, label: label.label)
+    }
+    
 }

--- a/Classes/Issues/Labels/IssueLabelsSectionController.swift
+++ b/Classes/Issues/Labels/IssueLabelsSectionController.swift
@@ -25,8 +25,8 @@ ListBindingSectionControllerSelectionDelegate {
 
     init(issue: IssueDetailsModel, tapDelegate: IssueLabelTapSectionControllerDelegate) {
         self.issue = issue
-        super.init()
         self.tapDelegate = tapDelegate
+        super.init()
         minimumInteritemSpacing = Styles.Sizes.labelSpacing
         minimumLineSpacing = Styles.Sizes.labelSpacing
         let row = Styles.Sizes.rowSpacing

--- a/Classes/Issues/Labels/IssueLabelsSectionController.swift
+++ b/Classes/Issues/Labels/IssueLabelsSectionController.swift
@@ -9,6 +9,11 @@
 import UIKit
 import IGListKit
 
+
+protocol IssueLabelTapSectionControllerDelegate: class {
+    func didTapLabel(owner: String, repo: String, label: String)
+}
+
 final class IssueLabelsSectionController: ListBindingSectionController<IssueLabelsModel>,
 ListBindingSectionControllerDataSource,
 ListBindingSectionControllerSelectionDelegate {
@@ -16,10 +21,12 @@ ListBindingSectionControllerSelectionDelegate {
     private let issue: IssueDetailsModel
     private var sizeCache = [String: CGSize]()
     private let lockedModel = Constants.Strings.locked
+    private weak var tapDelegate: IssueLabelTapSectionControllerDelegate?
 
-    init(issue: IssueDetailsModel) {
+    init(issue: IssueDetailsModel, tapDelegate: IssueLabelTapSectionControllerDelegate) {
         self.issue = issue
         super.init()
+        self.tapDelegate = tapDelegate
         minimumInteritemSpacing = Styles.Sizes.labelSpacing
         minimumLineSpacing = Styles.Sizes.labelSpacing
         let row = Styles.Sizes.rowSpacing
@@ -97,7 +104,7 @@ ListBindingSectionControllerSelectionDelegate {
 
     func sectionController(_ sectionController: ListBindingSectionController<ListDiffable>, didSelectItemAt index: Int, viewModel: Any) {
         guard let viewModel = viewModel as? RepositoryLabel else { return }
-        viewController?.presentLabels(owner: issue.owner, repo: issue.repo, label: viewModel.name)
+        tapDelegate?.didTapLabel(owner: issue.owner, repo: issue.repo, label: viewModel.name)
     }
 
 }

--- a/Classes/Issues/Labels/IssueLabelsSectionController.swift
+++ b/Classes/Issues/Labels/IssueLabelsSectionController.swift
@@ -11,7 +11,7 @@ import IGListKit
 
 
 protocol IssueLabelTapSectionControllerDelegate: class {
-    func didTapLabel(owner: String, repo: String, label: String)
+    func didTapIssueLabel(owner: String, repo: String, label: String)
 }
 
 final class IssueLabelsSectionController: ListBindingSectionController<IssueLabelsModel>,
@@ -104,7 +104,7 @@ ListBindingSectionControllerSelectionDelegate {
 
     func sectionController(_ sectionController: ListBindingSectionController<ListDiffable>, didSelectItemAt index: Int, viewModel: Any) {
         guard let viewModel = viewModel as? RepositoryLabel else { return }
-        tapDelegate?.didTapLabel(owner: issue.owner, repo: issue.repo, label: viewModel.name)
+        tapDelegate?.didTapIssueLabel(owner: issue.owner, repo: issue.repo, label: viewModel.name)
     }
 
 }

--- a/Classes/Repository/RepositoryIssuesViewController.swift
+++ b/Classes/Repository/RepositoryIssuesViewController.swift
@@ -26,12 +26,17 @@ SearchBarSectionControllerDelegate {
     private let searchKey: ListDiffable = "searchKey" as ListDiffable
     private let debouncer = Debouncer()
     private var previousSearchString = "is:open "
+    private var label: String?
 
-    init(client: GithubClient, owner: String, repo: String, type: RepositoryIssuesType) {
+    init(client: GithubClient, owner: String, repo: String, type: RepositoryIssuesType, label: String? = nil) {
         self.owner = owner
         self.repo = repo
         self.client = RepositoryClient(githubClient: client, owner: owner, name: repo)
         self.type = type
+        self.label = label
+        if let label = label {
+            previousSearchString += "label:\(label) "
+        }
 
         super.init(
             emptyErrorMessage: NSLocalizedString("Cannot load issues.", comment: "")
@@ -53,10 +58,13 @@ SearchBarSectionControllerDelegate {
         super.viewDidLoad()
 
         makeBackBarItemEmpty()
-
-        // set the frame in -viewDidLoad is required when working with TabMan
-        feed.collectionView.frame = view.bounds
-        feed.collectionView.contentInsetAdjustmentBehavior = .never
+        
+        let presentingInTabMan = label == nil
+        if presentingInTabMan {
+            // set the frame in -viewDidLoad is required when working with TabMan
+            feed.collectionView.frame = view.bounds
+            feed.collectionView.contentInsetAdjustmentBehavior = .never
+        }
     }
 
     // MARK: Overrides

--- a/Classes/Repository/RepositoryIssuesViewController.swift
+++ b/Classes/Repository/RepositoryIssuesViewController.swift
@@ -19,16 +19,18 @@ BaseListViewControllerDataSource,
 SearchBarSectionControllerDelegate {
 
     private var models = [ListDiffable]()
-    private let repo: RepositoryDetails
+    private let owner: String
+    private let repo: String
     private let client: RepositoryClient
     private let type: RepositoryIssuesType
     private let searchKey: ListDiffable = "searchKey" as ListDiffable
     private let debouncer = Debouncer()
     private var previousSearchString = "is:open "
 
-    init(client: GithubClient, repo: RepositoryDetails, type: RepositoryIssuesType) {
+    init(client: GithubClient, owner: String, repo: String, type: RepositoryIssuesType) {
+        self.owner = owner
         self.repo = repo
-        self.client = RepositoryClient(githubClient: client, owner: repo.owner, name: repo.name)
+        self.client = RepositoryClient(githubClient: client, owner: owner, name: repo)
         self.type = type
 
         super.init(
@@ -105,7 +107,7 @@ SearchBarSectionControllerDelegate {
                 query: previousSearchString
             )
         }
-        return RepositorySummarySectionController(client: client.githubClient, repo: repo)
+        return RepositorySummarySectionController(client: client.githubClient, owner: owner, repo: repo)
     }
 
     func emptySectionController(listAdapter: ListAdapter) -> ListSectionController {
@@ -129,7 +131,7 @@ SearchBarSectionControllerDelegate {
         case .issues: typeQuery = "is:issue"
         case .pullRequests: typeQuery = "is:pr"
         }
-        return "repo:\(repo.owner)/\(repo.name) \(typeQuery) \(previousSearchString)"
+        return "repo:\(owner)/\(repo) \(typeQuery) \(previousSearchString)"
     }
 
 }

--- a/Classes/Repository/RepositorySummarySectionController.swift
+++ b/Classes/Repository/RepositorySummarySectionController.swift
@@ -11,10 +11,12 @@ import IGListKit
 final class RepositorySummarySectionController: ListGenericSectionController<RepositoryIssueSummaryModel> {
 
     private let client: GithubClient
-    private let repo: RepositoryDetails
+    private let owner: String
+    private let repo: String
 
-    init(client: GithubClient, repo: RepositoryDetails) {
+    init(client: GithubClient, owner: String, repo: String) {
         self.client = client
+        self.owner = owner
         self.repo = repo
         super.init()
     }
@@ -53,7 +55,7 @@ final class RepositorySummarySectionController: ListGenericSectionController<Rep
 
     override func didSelectItem(at index: Int) {
         guard let number = self.object?.number else { return }
-        let issueModel = IssueDetailsModel(owner: repo.owner, repo: repo.name, number: number)
+        let issueModel = IssueDetailsModel(owner: owner, repo: repo, number: number)
         let controller = IssuesViewController(client: client, model: issueModel)
         viewController?.view.endEditing(false) // resign keyboard if it was triggered to become active by SearchBar 
         viewController?.navigationController?.pushViewController(controller, animated: trueUnlessReduceMotionEnabled)

--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -47,10 +47,10 @@ ContextMenuDelegate {
 
         var controllers: [UIViewController] = [RepositoryOverviewViewController(client: client, repo: repo)]
         if repo.hasIssuesEnabled {
-            controllers.append(RepositoryIssuesViewController(client: client, repo: repo, type: .issues))
+            controllers.append(RepositoryIssuesViewController(client: client, owner: repo.owner, repo: repo.name, type: .issues))
         }
         controllers += [
-            RepositoryIssuesViewController(client: client, repo: repo, type: .pullRequests),
+            RepositoryIssuesViewController(client: client, owner: repo.owner, repo: repo.name, type: .pullRequests),
             RepositoryCodeDirectoryViewController.createRoot(client: client, repo: repo, branch: repo.defaultBranch)
         ]
         self.controllers = controllers

--- a/Classes/Utility/UIViewController+Routing.swift
+++ b/Classes/Utility/UIViewController+Routing.swift
@@ -19,7 +19,6 @@ extension UIViewController {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             }
         case .username(let username): presentProfile(login: username)
-        case .label(let label): presentLabels(owner: label.owner, repo: label.repo, label: label.label)
         case .commit(let commit): presentCommit(owner: commit.owner, repo: commit.repo, hash: commit.hash)
         default: return false
         }

--- a/Classes/View Controllers/UIViewController+PresentLabels.swift
+++ b/Classes/View Controllers/UIViewController+PresentLabels.swift
@@ -1,0 +1,28 @@
+//
+//  UIViewController+PresentLabels.swift
+//  Freetime
+//
+//  Created by B_Litwin on 10/19/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import UIKit
+import GitHubAPI
+
+extension UIViewController {
+    func presentLabels(client: GithubClient, owner: String, repo: String, label: String) {
+        let repositoryIssuesViewController =
+            RepositoryIssuesViewController(
+                client: client,
+                owner: owner,
+                repo: repo,
+                type: .issues,
+                label: label
+        )
+        
+        navigationController?.pushViewController(
+            repositoryIssuesViewController,
+            animated: true
+        )
+    }
+}

--- a/Classes/View Controllers/UIViewController+Safari.swift
+++ b/Classes/View Controllers/UIViewController+Safari.swift
@@ -30,11 +30,6 @@ extension UIViewController {
         presentSafari(url: url)
     }
 
-    func presentLabels(owner: String, repo: String, label: String) {
-        guard let url = URL(string: "https://github.com/\(owner)/\(repo)/labels/\(label)") else { return }
-        presentSafari(url: url)
-    }
-
     func presentMilestone(owner: String, repo: String, milestone: Int) {
         guard let url = URL(string: "https://github.com/\(owner)/\(repo)/milestone/\(milestone)") else { return }
         presentSafari(url: url)

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -449,6 +449,7 @@
 		98F9F4011F9CCFFE005A0266 /* ImgurClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F9F3FE1F9CCFFE005A0266 /* ImgurClient.swift */; };
 		98F9F4031F9CD006005A0266 /* Image+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F9F4021F9CD006005A0266 /* Image+Base64.swift */; };
 		BD3761B0209E032500401DFB /* BookmarkNavigationItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD3761AF209E032500401DFB /* BookmarkNavigationItemTests.swift */; };
+		BD67495C217A47BC00E8E4FD /* UIViewController+PresentLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD67495B217A47BC00E8E4FD /* UIViewController+PresentLabels.swift */; };
 		BD89007E20B8844B0026013F /* NetworkingURLPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD89007D20B8844B0026013F /* NetworkingURLPathTests.swift */; };
 		BDB6AA66215FBC35009BB73C /* RepositoryBranchesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB6AA5F215FBC35009BB73C /* RepositoryBranchesViewModel.swift */; };
 		BDB6AA67215FBC35009BB73C /* RepositoryBranchUpdatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB6AA60215FBC35009BB73C /* RepositoryBranchUpdatable.swift */; };
@@ -999,6 +1000,7 @@
 		ACAE4A11E9671879046F0CE7 /* Pods-FreetimeWatch.testflight.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FreetimeWatch.testflight.xcconfig"; path = "Pods/Target Support Files/Pods-FreetimeWatch/Pods-FreetimeWatch.testflight.xcconfig"; sourceTree = "<group>"; };
 		B3C439BE890EECD7C0C692C5 /* Pods-Freetime.testflight.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Freetime.testflight.xcconfig"; path = "Pods/Target Support Files/Pods-Freetime/Pods-Freetime.testflight.xcconfig"; sourceTree = "<group>"; };
 		BD3761AF209E032500401DFB /* BookmarkNavigationItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkNavigationItemTests.swift; sourceTree = "<group>"; };
+		BD67495B217A47BC00E8E4FD /* UIViewController+PresentLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+PresentLabels.swift"; sourceTree = "<group>"; };
 		BD89007D20B8844B0026013F /* NetworkingURLPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingURLPathTests.swift; sourceTree = "<group>"; };
 		BDB6AA5F215FBC35009BB73C /* RepositoryBranchesViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepositoryBranchesViewModel.swift; sourceTree = "<group>"; };
 		BDB6AA60215FBC35009BB73C /* RepositoryBranchUpdatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepositoryBranchUpdatable.swift; sourceTree = "<group>"; };
@@ -1743,6 +1745,7 @@
 				290056F2210028B20046EAE5 /* UIViewController+MenuDone.swift */,
 				29792B181FFB10A3007A0C57 /* UIViewController+MessageAutocompleteControllerLayoutDelegate.swift */,
 				292CD3D11F0DBEC000D3D57B /* UIViewController+Safari.swift */,
+				BD67495B217A47BC00E8E4FD /* UIViewController+PresentLabels.swift */,
 				290D2A3C1F044CB20082E6CC /* UIViewController+SmartDeselection.swift */,
 				299F63E3205E1CAB0015D901 /* UIViewController+StyledTextViewCellDelegate.swift */,
 				4920F1A71F72E27200131E9D /* UIViewController+UserActivity.swift */,
@@ -2762,6 +2765,7 @@
 				29459A6F1FE61E0500034A04 /* MarkdownCheckboxModel.swift in Sources */,
 				299997302031227E00995FFD /* IssueMergeButtonModel.swift in Sources */,
 				29CEA5CD1F84DB1B009827DB /* BaseListViewController.swift in Sources */,
+				BD67495C217A47BC00E8E4FD /* UIViewController+PresentLabels.swift in Sources */,
 				299F63E0205DDF6B0015D901 /* UIViewController+Routing.swift in Sources */,
 				98835BD41F1A17EE005BA24F /* Bundle+Version.swift in Sources */,
 				29316DB51ECC7DEB007CAE3F /* ButtonCell.swift in Sources */,


### PR DESCRIPTION
My second go at #2309 -> see that PR for vid. Functionality is the same. The difference is instead of passing the `GithubClient` around as a parameter in the LabelDetails model, used a protocol to route the tap to a view controller with access to `GithubClient`. Also, in order to do that, re-wired the IssueLabel SectionControllers to be the `MarkdownStyledTextViewDelegate` so that they could receive those taps and re-route them to the delegate w/ access to `GithubClient`. 

