### PR TITLE
Improve empty retry UX

### DIFF
--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -619,8 +619,8 @@ final class IssuesViewController: MessageViewController,
 
     // MARK: EmptyViewDelegate
 
-    func didTapRetry() {
-        self.feed.refreshHead()
+    func didTapRetry(view: EmptyView) {
+        feed.refreshHead()
     }
 
     // MARK: MessageTextViewListener

--- a/Classes/PullRequestReviews/PullRequestReviewCommentsViewController.swift
+++ b/Classes/PullRequestReviews/PullRequestReviewCommentsViewController.swift
@@ -193,8 +193,8 @@ final class PullRequestReviewCommentsViewController: MessageViewController,
 
     // MARK: EmptyViewDelegate
 
-    func didTapRetry() {
-        self.feed.refreshHead()
+    func didTapRetry(view: EmptyView) {
+        feed.refreshHead()
     }
 
     // MARK: IssueTextActionsViewSendDelegate

--- a/Classes/Repository/RepositoryCodeBlobViewController.swift
+++ b/Classes/Repository/RepositoryCodeBlobViewController.swift
@@ -169,8 +169,8 @@ final class RepositoryCodeBlobViewController: UIViewController, EmptyViewDelegat
 
     // MARK: EmptyViewDelegate
 
-    func didTapRetry() {
-        self.onRefresh()
+    func didTapRetry(view: EmptyView) {
+        onRefresh()
     }
 
 }

--- a/Classes/Repository/RepositoryWebViewController.swift
+++ b/Classes/Repository/RepositoryWebViewController.swift
@@ -133,8 +133,8 @@ extension RepositoryWebViewController: WKNavigationDelegate {
 
 extension RepositoryWebViewController: EmptyViewDelegate {
 
-    func didTapRetry() {
-        self.fetch()
+    func didTapRetry(view: EmptyView) {
+        fetch()
     }
 
 }

--- a/Classes/Search/SearchViewController.swift
+++ b/Classes/Search/SearchViewController.swift
@@ -235,7 +235,7 @@ class SearchViewController: UIViewController,
 
     // MARK: EmptyViewDelegate
 
-    func didTapRetry() {
+    func didTapRetry(view: EmptyView) {
         searchBar.resignFirstResponder()
 
         guard let term = searchTerm(for: searchBar.text) else { return }

--- a/Classes/View Controllers/BaseListViewController.swift
+++ b/Classes/View Controllers/BaseListViewController.swift
@@ -78,7 +78,7 @@ LoadMoreSectionControllerDelegate {
     // MARK: Public API
 
     final func update(animated: Bool) {
-        self.feed.finishLoading(dismissRefresh: true, animated: animated)
+        feed.finishLoading(dismissRefresh: true, animated: animated)
     }
 
     final func update(
@@ -88,9 +88,9 @@ LoadMoreSectionControllerDelegate {
         ) {
         assert(Thread.isMainThread)
 
-        self.hasError = false
+        hasError = false
         self.page = page
-        self.feed.finishLoading(dismissRefresh: true, animated: animated, completion: completion)
+        feed.finishLoading(dismissRefresh: true, animated: animated, completion: completion)
     }
 
     final func error(
@@ -179,8 +179,11 @@ LoadMoreSectionControllerDelegate {
 
     // MARK: EmptyViewDelegate
 
-    func didTapRetry() {
-        self.feed.refreshHead()
+    func didTapRetry(view: EmptyView) {
+        // order is required to hide the error empty view while loading
+        feed.refreshHead()
+        hasError = false
+        feed.adapter.performUpdates(animated: false, completion: nil)
     }
 
     // MARK: LoadMoreSectionControllerDelegate

--- a/Classes/View Controllers/BaseListViewController2.swift
+++ b/Classes/View Controllers/BaseListViewController2.swift
@@ -169,8 +169,11 @@ EmptyViewDelegate {
 
     // MARK: EmptyViewDelegate
 
-    func didTapRetry() {
-        self.feed.refreshHead()
+    func didTapRetry(view: EmptyView) {
+        // order is required to hide the error empty view while loading
+        feed.refreshHead()
+        hasError = false
+        feed.adapter.performUpdates(animated: false, completion: nil)
     }
 
 }

--- a/Classes/Views/Constants.swift
+++ b/Classes/Views/Constants.swift
@@ -56,7 +56,6 @@ enum Constants {
         static let assignees = NSLocalizedString("Assignees", comment: "")
         static let reviewers = NSLocalizedString("Reviewers", comment: "")
         static let reviewGitHubAccess = NSLocalizedString("Review GitHub Access", comment: "")
-        static let tryAgain = NSLocalizedString("Try Again", comment: "")
         static let clear = NSLocalizedString("Clear", comment: "")
     }
 }

--- a/Classes/Views/EmptyView.swift
+++ b/Classes/Views/EmptyView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 
 protocol EmptyViewDelegate: class {
-    func didTapRetry()
+    func didTapRetry(view: EmptyView)
 }
 
 final class EmptyView: UIView {
@@ -30,8 +30,8 @@ final class EmptyView: UIView {
         addSubview(label)
 
         button.isHidden = true
-        button.titleLabel?.font = Styles.Text.button.preferredFont
-        button.setTitle(Constants.Strings.tryAgain, for: .normal)
+        button.titleLabel?.font = Styles.Text.secondaryBold.preferredFont
+        button.setTitle(NSLocalizedString("Try Again", comment: ""), for: .normal)
         button.setTitleColor(Styles.Colors.Blue.medium.color, for: .normal)
         button.addTarget(self, action: #selector(tapRetry), for: .touchUpInside)
         addSubview(button)
@@ -43,7 +43,7 @@ final class EmptyView: UIView {
 
         button.snp.makeConstraints { make in
             make.centerX.equalTo(self)
-            make.top.equalTo(label).offset(Styles.Sizes.gutter)
+            make.top.equalTo(label).offset(2*Styles.Sizes.gutter)
         }
     }
 
@@ -52,6 +52,6 @@ final class EmptyView: UIView {
     }
 
     @objc private func tapRetry(sender: UIButton) {
-        delegate?.didTapRetry()
+        delegate?.didTapRetry(view: self)
     }
 }


### PR DESCRIPTION
Cleaned up the UX

- Smaller, bolder text to distinguish it from the empty message
- More vertical spacing
- Hide the empty view when loading again
- Code cleanup

![simulator screen shot - iphone xs - 2018-10-20 at 17 10 44](https://user-images.githubusercontent.com/739696/47260566-fd4c9f80-d48b-11e8-9ca6-b854774db6d8.png)
