### PR TITLE
Use https url for login

### DIFF
--- a/Classes/Login/LoginSplashViewController.swift
+++ b/Classes/Login/LoginSplashViewController.swift
@@ -11,7 +11,7 @@ import SafariServices
 import GitHubAPI
 import GitHubSession
 
-private let loginURL = URL(string: "http://github.com/login/oauth/authorize?client_id=\(Secrets.GitHub.clientId)&scope=user+repo+notifications")!
+private let loginURL = URL(string: "https://github.com/login/oauth/authorize?client_id=\(Secrets.GitHub.clientId)&scope=user+repo+notifications")!
 private let callbackURLScheme = "freetime://"
 
 protocol LoginSplashViewControllerDelegate: class {


### PR DESCRIPTION
Removes a deprecation warning for SFAuthentication because of using http