### PR TITLE
cleans up issue labels query

### DIFF
--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -54,6 +54,7 @@ final class IssuesViewController: MessageViewController,
     private var needsScrollToBottom = false
     private var lastTimelineElement: ListDiffable?
     private var actions: IssueTextActionsView?
+    private var issueType: RepositoryIssuesType?
 
     // must fetch collaborator info from API before showing editing controls
     private var viewerIsCollaborator = false
@@ -333,6 +334,7 @@ final class IssuesViewController: MessageViewController,
                 )
                 strongSelf.client.cache.add(listener: strongSelf, value: result)
                 strongSelf.resultID = result.id
+                strongSelf.issueType = result.pullRequest ? .pullRequests : .issues
             default: break
             }
 
@@ -636,7 +638,8 @@ final class IssuesViewController: MessageViewController,
     // MARK: IssueLabelsSectionControllerDelegate
     
     func didTapIssueLabel(owner: String, repo: String, label: String) {
-        presentLabels(client: client, owner: owner, repo: repo, label: label)
+        guard let issueType = self.issueType else { return }
+        presentLabels(client: client, owner: owner, repo: repo, label: label, type: issueType)
     }
 
 }

--- a/Classes/Repository/RepositoryIssuesViewController.swift
+++ b/Classes/Repository/RepositoryIssuesViewController.swift
@@ -35,7 +35,7 @@ SearchBarSectionControllerDelegate {
         self.type = type
         self.label = label
         if let label = label {
-            previousSearchString += "label:\(label) "
+            previousSearchString += "label:\"\(label)\" "
         }
 
         super.init(

--- a/Classes/View Controllers/UIViewController+PresentLabels.swift
+++ b/Classes/View Controllers/UIViewController+PresentLabels.swift
@@ -10,13 +10,13 @@ import UIKit
 import GitHubAPI
 
 extension UIViewController {
-    func presentLabels(client: GithubClient, owner: String, repo: String, label: String) {
+    func presentLabels(client: GithubClient, owner: String, repo: String, label: String, type: RepositoryIssuesType) {
         let repositoryIssuesViewController =
             RepositoryIssuesViewController(
                 client: client,
                 owner: owner,
                 repo: repo,
-                type: .issues,
+                type: type,
                 label: label
         )
         


### PR DESCRIPTION
Fixes #2332 and #2333 

Tested manually that: 
- Multi-word labels or labels w/ emoji's in them query correctly 
- tapping labels on pull requests pushes a list of Pull Requests, and tapping Issue labels pushes a list of Issues 
