### PR TITLE
Update reivewGitHUbAccessBtn constraints

### DIFF
--- a/Classes/Notifications/NoNewNotificationsCell.swift
+++ b/Classes/Notifications/NoNewNotificationsCell.swift
@@ -46,6 +46,7 @@ final class NoNewNotificationsCell: UICollectionViewCell {
         messageLabel.snp.makeConstraints { make in
             make.centerX.equalTo(emojiLabel)
             make.top.equalTo(emojiLabel.snp.bottom).offset(Styles.Sizes.tableSectionSpacing)
+            make.height.greaterThanOrEqualTo(messageLabel.font.pointSize)
         }
 
         resetAnimations()
@@ -77,7 +78,9 @@ final class NoNewNotificationsCell: UICollectionViewCell {
             make.centerX.equalTo(messageLabel)
             make.width.equalTo(buttonWidth)
             make.height.equalTo(buttonHeight)
-            make.bottom.equalTo(contentView.snp.bottom).offset(-Styles.Sizes.tableSectionSpacing)
+            make.top.greaterThanOrEqualTo(messageLabel.snp.bottom)
+            make.bottom.equalTo(contentView.snp.bottom).offset(-Styles.Sizes.tableSectionSpacing).priority(.low)
+            make.bottom.lessThanOrEqualTo(contentView.snp.bottom)
         }
 
     }


### PR DESCRIPTION
Connected to #2319 

I believe this will fix the constraint bugginess referenced in the screenshot in #2319 - to reproduce that, use a 5s phone in the simulator and go to landscape. 

I adjusted the constraints such that the "ReviewGithubAccess" btn will move closer to the bottom border if its superview is height-constrained. 

Bordered the contentView in blue and set arbitrary height constraints in following screenshots: 

#### 5s landscape 

<img width="510" alt="screenshot 2018-10-21 17 21 11" src="https://user-images.githubusercontent.com/26695477/47272632-63055e00-d556-11e8-8d40-653e205baffd.png">

#### 200 pt height (slightly smaller than 5s landscape, checking that reviewGithubAccess button gets closer to bottom of superview)  

<img width="284" alt="screenshot 2018-10-21 17 19 27" src="https://user-images.githubusercontent.com/26695477/47272636-731d3d80-d556-11e8-903d-bec89bac7eb8.png">

#### extreme case: 150pt height; animation becomes obscured. Slightly better outcome than button moving off the end of the contentView, where it would be unresponsive.

<img width="281" alt="screenshot 2018-10-21 17 18 31" src="https://user-images.githubusercontent.com/26695477/47272638-7d3f3c00-d556-11e8-9db0-72d8eaa12c2b.png">
