### PR TITLE
Message on "Try Beta"  when already in TF

### DIFF
--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -195,9 +195,13 @@ NewIssueTableViewControllerDelegate {
     }
 
     func onTryTestFlightBeta() {
+        #if TESTFLIGHT
+        Squawk.showAlreadyOnBeta()
+        #else
         guard let url = URL(string: "https://testflight.apple.com/join/QIVXLkkn")
             else { fatalError("Failed to decode testflight beta URL") }
         presentSafari(url: url)
+        #endif
     }
 
     func onSignOut() {

--- a/Classes/Systems/Squawk+GitHawk.swift
+++ b/Classes/Systems/Squawk+GitHawk.swift
@@ -27,6 +27,17 @@ extension Squawk {
         )
     }
 
+    static func showAlreadyOnBeta(view: UIView? = window) {
+        let config = Squawk.Configuration(
+            text: NSLocalizedString("You're Already on Beta.👌", comment: ""),
+            backgroundColor: UIColor.black.withAlphaComponent(0.5),
+            insets: UIEdgeInsets(top: Styles.Sizes.rowSpacing, left: Styles.Sizes.gutter, bottom: Styles.Sizes.rowSpacing, right: Styles.Sizes.gutter),
+            hintMargin: Styles.Sizes.rowSpacing
+        )
+        Squawk.shared.show(in: view, config: config)
+        triggerHaptic()
+    }
+
     static func showRevokeError(view: UIView? = window) {
         Squawk.shared.show(in: view, config: errorConfig(text: NSLocalizedString("Your access token was revoked.", comment: "")))
         triggerHaptic()

--- a/Classes/Systems/Squawk+GitHawk.swift
+++ b/Classes/Systems/Squawk+GitHawk.swift
@@ -29,9 +29,14 @@ extension Squawk {
 
     static func showAlreadyOnBeta(view: UIView? = window) {
         let config = Squawk.Configuration(
-            text: NSLocalizedString("You're Already on Beta.👌", comment: ""),
+            text: NSLocalizedString("You're are already using a TestFlight build. 👌", comment: ""),
             backgroundColor: UIColor.black.withAlphaComponent(0.5),
-            insets: UIEdgeInsets(top: Styles.Sizes.rowSpacing, left: Styles.Sizes.gutter, bottom: Styles.Sizes.rowSpacing, right: Styles.Sizes.gutter),
+            insets: UIEdgeInsets(
+                top: Styles.Sizes.rowSpacing,
+                left: Styles.Sizes.gutter,
+                bottom: Styles.Sizes.rowSpacing,
+                right: Styles.Sizes.gutter
+            ),
             hintMargin: Styles.Sizes.rowSpacing
         )
         Squawk.shared.show(in: view, config: config)


### PR DESCRIPTION
Continuing from PR #2346 

Shows a Squawk message when user is already on beta and tapping "Try Beta" on settings screen.

This is how it looks. Feel free to change the colour of the Squawk or message.

![screenshot 2018-10-25 at 1 03 56 pm](https://user-images.githubusercontent.com/12063704/47483271-7cf4b880-d856-11e8-9a45-2d22e8340c6f.png)