### PR TITLE
Allow showing/cloning repository in Working Copy when installed

### DIFF
--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -159,6 +159,20 @@ ContextMenuDelegate {
             .newIssue(issueController: newIssueViewController)
     }
 
+    func workingCopyAction() -> UIAlertAction? {
+        guard let remote = self.repoUrl.absoluteString.addingPercentEncoding(withAllowedCharacters: CharacterSet.alphanumerics) else { return nil}
+
+        guard let url = URL(string: "working-copy://show?remote=\(remote)") else { return nil }
+        guard UIApplication.shared.canOpenURL(url) else { return nil }
+
+        let title = NSLocalizedString("Working Copy", comment: "")
+        let action = UIAlertAction(title: title, style: .default,
+                                   handler: { _ in
+            UIApplication.shared.open(url)
+        })
+        return action
+    }
+
     @objc func onMore(sender: UIButton) {
         let alertTitle = "\(repo.owner)/\(repo.name):\(branch)"
         let alert = UIAlertController.configured(title: alertTitle, preferredStyle: .actionSheet)
@@ -173,6 +187,7 @@ ContextMenuDelegate {
                 $0.popoverPresentationController?.setSourceView(sender)
             },
             switchBranchAction,
+            workingCopyAction(),
             AlertAction.cancel()
         ])
         alert.popoverPresentationController?.setSourceView(sender)

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -52,6 +52,7 @@
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>org-appextension-feature-password-management</string>
+		<string>working-copy</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
.../more button when looking at repository has extra action when Working Copy is installed
to show or clone repository in this app.

This should address #2342