### PR TITLE
[2385] shortlink regex patch

### DIFF
--- a/Classes/Issues/Comments/Markdown/String+DetectShortlink.swift
+++ b/Classes/Issues/Comments/Markdown/String+DetectShortlink.swift
@@ -16,7 +16,7 @@ extension NSRange {
     }
 }
 
-private let regex = try! NSRegularExpression(pattern: "(^|\\s|[^a-zA-Z])((\\w+)/(\\w+))?#([0-9]+)(?![a-zA-Z0-9])", options: [])
+private let regex = try! NSRegularExpression(pattern: "(^|\\s|[^a-zA-Z0-9/])(([\\w|-]+)/([\\w|-]+))?#([0-9]+)(?![a-zA-Z0-9])", options: [])
 extension String {
     func detectAndHandleShortlink(owner: String, repo: String, builder: StyledTextBuilder) {
         let matches = regex.matches(in: self, options: [], range: nsrange)

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 		98F9F4001F9CCFFE005A0266 /* ImageUploadTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F9F3FD1F9CCFFE005A0266 /* ImageUploadTableViewController.swift */; };
 		98F9F4011F9CCFFE005A0266 /* ImgurClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F9F3FE1F9CCFFE005A0266 /* ImgurClient.swift */; };
 		98F9F4031F9CD006005A0266 /* Image+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F9F4021F9CD006005A0266 /* Image+Base64.swift */; };
+		BD1DC658218DFE3D004DAC42 /* DetectShortlinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1DC657218DFE3C004DAC42 /* DetectShortlinkTests.swift */; };
 		BD3761B0209E032500401DFB /* BookmarkNavigationItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD3761AF209E032500401DFB /* BookmarkNavigationItemTests.swift */; };
 		BD67495C217A47BC00E8E4FD /* UIViewController+PresentLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD67495B217A47BC00E8E4FD /* UIViewController+PresentLabels.swift */; };
 		BD89007E20B8844B0026013F /* NetworkingURLPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD89007D20B8844B0026013F /* NetworkingURLPathTests.swift */; };
@@ -1015,6 +1016,7 @@
 		A4D6EAEE85A1F4878338D48C /* Pods-FreetimeWatch Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FreetimeWatch Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-FreetimeWatch Extension/Pods-FreetimeWatch Extension.debug.xcconfig"; sourceTree = "<group>"; };
 		ACAE4A11E9671879046F0CE7 /* Pods-FreetimeWatch.testflight.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FreetimeWatch.testflight.xcconfig"; path = "Pods/Target Support Files/Pods-FreetimeWatch/Pods-FreetimeWatch.testflight.xcconfig"; sourceTree = "<group>"; };
 		B3C439BE890EECD7C0C692C5 /* Pods-Freetime.testflight.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Freetime.testflight.xcconfig"; path = "Pods/Target Support Files/Pods-Freetime/Pods-Freetime.testflight.xcconfig"; sourceTree = "<group>"; };
+		BD1DC657218DFE3C004DAC42 /* DetectShortlinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetectShortlinkTests.swift; sourceTree = "<group>"; };
 		BD3761AF209E032500401DFB /* BookmarkNavigationItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkNavigationItemTests.swift; sourceTree = "<group>"; };
 		BD67495B217A47BC00E8E4FD /* UIViewController+PresentLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+PresentLabels.swift"; sourceTree = "<group>"; };
 		BD89007D20B8844B0026013F /* NetworkingURLPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingURLPathTests.swift; sourceTree = "<group>"; };
@@ -1614,6 +1616,7 @@
 				2981A8A61EFEBEF900E25EF1 /* EmojiTests.swift */,
 				2986B35D1FD462AA00E3CFC6 /* FilePathTests.swift */,
 				296B4E331F7C80B800C16887 /* GraphQLIDDecodeTests.swift */,
+				BD1DC657218DFE3C004DAC42 /* DetectShortlinkTests.swift */,
 				297AE84E1EC0D58A00B44A1F /* Info.plist */,
 				DC60C6D41F983DF800241271 /* IssueLabelCellTests.swift */,
 				29A476B11ED24D99005D0953 /* IssueTests.swift */,
@@ -3236,6 +3239,7 @@
 				DC5C02C51F9C6E3500E80B9F /* SearchQueryTests.swift in Sources */,
 				293A457E1F296BD500DD1006 /* API.swift in Sources */,
 				49AF91B1204B416500DFF325 /* MergeTests.swift in Sources */,
+				BD1DC658218DFE3D004DAC42 /* DetectShortlinkTests.swift in Sources */,
 				2986B35F1FD462B300E3CFC6 /* FilePath.swift in Sources */,
 				293A45781F296B7E00DD1006 /* ListTestKit.swift in Sources */,
 				296B4E341F7C80B800C16887 /* GraphQLIDDecodeTests.swift in Sources */,

--- a/FreetimeTests/DetectShortlinkTests.swift
+++ b/FreetimeTests/DetectShortlinkTests.swift
@@ -123,12 +123,36 @@ class DetectShortlinkTests: XCTestCase {
         XCTAssertEqual(containsLink.linkText, "#4")
         XCTAssertEqual(containsLink.issueNumber, 4)
         XCTAssertEqual(builder.allText, testString)
+        
+        // dash in repository name
+        testString = "Unibeautify/unibeautify-cli#115"
+        builder = setupBuilder(with: testString)
+        containsLink = checkForIssueLink(builder.styledTexts)[0]
+        XCTAssertEqual(containsLink.linkText, "Unibeautify/unibeautify-cli#115")
+        XCTAssertEqual(containsLink.issueNumber, 115)
+        XCTAssertEqual(builder.allText, testString)
+        
+        //leading underscore
+        testString = "_#115"
+        builder = setupBuilder(with: testString)
+        containsLink = checkForIssueLink(builder.styledTexts)[0]
+        XCTAssertEqual(containsLink.linkText, "#115")
+        XCTAssertEqual(containsLink.issueNumber, 115)
+        XCTAssertEqual(builder.allText, testString)
+        
+        //trailing underscore
+        testString = "#115_"
+        builder = setupBuilder(with: testString)
+        containsLink = checkForIssueLink(builder.styledTexts)[0]
+        XCTAssertEqual(containsLink.linkText, "#115")
+        XCTAssertEqual(containsLink.issueNumber, 115)
+        XCTAssertEqual(builder.allText, testString)
     }
 
     func test_ConsecutivePositiveMatches() {
-        var testString = "#100 #150 #200"
-        var builder = setupBuilder(with: testString)
-        var links = checkForIssueLink(builder.styledTexts)
+        let testString = "#100 #150 #200"
+        let builder = setupBuilder(with: testString)
+        let links = checkForIssueLink(builder.styledTexts)
 
         XCTAssertEqual(links[0].issueNumber, 100)
         XCTAssertEqual(links[0].linkText, "#100")
@@ -154,6 +178,15 @@ class DetectShortlinkTests: XCTestCase {
         XCTAssertEqual(containsLink.count, 0)
 
         builder = setupBuilder(with: "f#123")
+        containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertEqual(containsLink.count, 0)
+        
+        // format should be f/f/#123
+        builder = setupBuilder(with: "f/#123")
+        containsLink = checkForIssueLink(builder.styledTexts)
+        XCTAssertEqual(containsLink.count, 0)
+        
+        builder = setupBuilder(with: "1#1")
         containsLink = checkForIssueLink(builder.styledTexts)
         XCTAssertEqual(containsLink.count, 0)
     }


### PR DESCRIPTION
Connected to #2385 

This will allow dashes in owner and repository names - 

Updated screenshot: 

<img width="296" alt="screenshot 2018-11-04 10 30 27" src="https://user-images.githubusercontent.com/26695477/47966156-3143cb00-e01d-11e8-8cd0-cf72e79d16df.png">

Added the above case to the unit tests. 

I also added some test cases to be explicit about allowing underscores before and after Issues. I was considering replacing `[a-zA-Z0-9]` with `\w` in a few places for brevity, but GitHub allows the underscore before and after an issue. Ie GitHub will recognize `_#1` and `#1_` as Issues and link them.