### PR TITLE
WIP - Templates

### DIFF
--- a/Classes/New Issue/IssueTemplates.swift
+++ b/Classes/New Issue/IssueTemplates.swift
@@ -1,0 +1,220 @@
+//
+//  IssueTemplates.swift
+//  Freetime
+//
+//  Created by Ehud Adler on 11/3/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import Foundation
+import GitHubAPI
+import GitHubSession
+import Squawk
+
+struct IssueTemplate {
+    let title:String
+    let template:String
+}
+
+enum IssueTemplateHelper {
+
+    static private func matchesForRegexInText(
+        regex: String!,
+        text: String!) -> [String] {
+
+        do {
+            let regex = try NSRegularExpression(pattern: regex, options: [])
+            let nsString = text as NSString
+
+            let results = regex.matches(
+                in: text,
+                options: [],
+                range: NSMakeRange(0, nsString.length))
+            return results.map { nsString.substring(with: $0.range)}
+
+        } catch let error as NSError {
+            print("invalid regex: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    static func getNameAndDescriptionFromTemplateFile(file: String) -> (name: String?, about: String?) {
+
+        let names = IssueTemplateHelper.matchesForRegexInText(regex: "(?<=name:).*", text: file)
+        let abouts = IssueTemplateHelper.matchesForRegexInText(regex: "(?<=about:).*", text: file)
+        let name = names.count > 0
+            ? names[0].trimmingCharacters(in: .whitespaces)
+            : nil
+        let about = abouts.count > 0
+            ? abouts[0].trimmingCharacters(in: .whitespaces)
+            : nil
+        return (name, about)
+    }
+
+    static func showIssueAlert(
+        with templates: [IssueTemplate],
+        owner: String,
+        repo: String,
+        session: GitHubUserSession?,
+        mainViewController: UIViewController,
+        delegate: NewIssueTableViewControllerDelegate) {
+
+        let alertView = UIAlertController(
+            title: NSLocalizedString("New Issue", comment: ""),
+            message: NSLocalizedString("Choose Template", comment: ""),
+            preferredStyle: .alert
+        )
+
+        for template in templates {
+            alertView.addAction(
+                UIAlertAction(
+                    title: template.title,
+                    style: .default,
+                    handler: { _ in
+
+                        guard let viewController = NewIssueTableViewController.createWithTemplate(
+                            client: GithubClient(userSession: session),
+                            owner: owner,
+                            repo: repo,
+                            template: template.template,
+                            signature: template.title == "Bug Report" ? .bugReport : .sentWithGitHawk
+                            ) else {
+                                Squawk.showGenericError()
+                                return
+                        }
+                        viewController.delegate = delegate
+                        let navController = UINavigationController(rootViewController: viewController)
+                        navController.modalPresentationStyle = .formSheet
+                        mainViewController.present(navController, animated: trueUnlessReduceMotionEnabled)
+                }))
+        }
+
+        alertView.addAction(
+            UIAlertAction(
+                title: "Dismiss",
+                style: UIAlertActionStyle.cancel,
+                handler: { _ in
+                    alertView.dismiss(animated: true, completion: nil)
+            })
+        )
+        mainViewController.present(alertView, animated: true, completion: nil)
+    }
+}
+
+extension GithubClient {
+
+    private func fetchTemplateFile(
+        owner: String,
+        repo: String,
+        filename: String,
+        completion: @escaping (Result<String>) -> Void
+        ) {
+
+        self.fetchFile(
+            owner: owner,
+            repo: repo,
+            branch: "master",
+            path: ".github/ISSUE_TEMPLATE/\(filename)") { (result) in
+                switch result {
+                case .success(let file):
+                    completion(.success(file))
+                case .error(let error):
+                    completion(.error(error))
+                case .nonUTF8:
+                    completion(.error(nil))
+                }
+        }
+    }
+
+    private func createTemplateWith(
+        owner: String,
+        repo: String,
+        filename: String,
+        completion: @escaping (Result<IssueTemplate>) -> Void
+        ) {
+        fetchTemplateFile(owner: owner, repo: repo, filename: filename) { (result) in
+            switch result {
+            case .success(let file):
+                let nameAndDescription = IssueTemplateHelper.getNameAndDescriptionFromTemplateFile(file: file)
+                if let name = nameAndDescription.name {
+                    completion(.success(IssueTemplate(title: name, template: file)))
+                } else {
+                    completion(.error(nil))
+                }
+            case .error(let error):
+                completion(.error(error))
+            }
+        }
+    }
+
+    func createNewIssue(
+        owner: String,
+        repo: String,
+        session: GitHubUserSession?,
+        mainViewController: UIViewController,
+        delegate: NewIssueTableViewControllerDelegate) {
+
+        var templates: [IssueTemplate] = []
+        let templateGroup = DispatchGroup()
+
+        self.fetchFiles(
+            owner: owner,
+            repo: repo,
+            branch: "master",
+            path: ".github/ISSUE_TEMPLATE") { (result) in
+                switch result {
+                case .success(let files):
+                    for file in files {
+                        templateGroup.enter()
+                        self.createTemplateWith(owner: owner, repo: repo, filename: file.name, completion: {
+                            switch $0 {
+                            case .success(let template):
+                                templates.append(template)
+                            case .error(let error):
+                                if let err = error {
+                                    Squawk.show(error: err)
+                                }
+                            }
+                            templateGroup.leave()
+                        })
+                    }
+                case .error(let error):
+                    Squawk.show(error: error)
+                }
+
+                // Wait for async calls in for-loop to finish up
+                templateGroup.notify(queue: .main) {
+
+                    // Sort lexicographically
+                    let sortedTemplates = templates.sorted(by: {$0.title < $1.title })
+
+                    if sortedTemplates.count > 0 {
+                        // Templates exists...
+                        IssueTemplateHelper.showIssueAlert(
+                            with: sortedTemplates,
+                            owner: owner,
+                            repo: repo,
+                            session: session,
+                            mainViewController: mainViewController,
+                            delegate: delegate
+                        )
+                    } else {
+                        // No templates exists, show blank new issue view controller
+                        guard let viewController = NewIssueTableViewController.create(
+                            client: GithubClient(userSession: session),
+                            owner: owner,
+                            repo: repo,
+                            signature: .sentWithGitHawk
+                            ) else {
+                                Squawk.showGenericError()
+                                return
+                        }
+                        viewController.delegate = delegate
+                        let navController = UINavigationController(rootViewController: viewController)
+                        navController.modalPresentationStyle = .formSheet
+                        mainViewController.present(navController, animated: trueUnlessReduceMotionEnabled)
+                    }
+                }
+        }
+    }
+}

--- a/Classes/New Issue/NewIssueTableViewController.swift
+++ b/Classes/New Issue/NewIssueTableViewController.swift
@@ -51,6 +51,7 @@ final class NewIssueTableViewController: UITableViewController, UITextFieldDeleg
     @IBOutlet var titleField: UITextField!
     @IBOutlet var bodyField: UITextView!
 
+    private var template: String = ""
     private var client: GithubClient!
     private var owner: String!
     private var repo: String!
@@ -85,6 +86,26 @@ final class NewIssueTableViewController: UITableViewController, UITextFieldDeleg
         return viewController
     }
 
+    static func createWithTemplate(
+        client: GithubClient,
+        owner: String,
+        repo: String,
+        template: String,
+        signature: IssueSignatureType? = nil) -> NewIssueTableViewController? {
+
+        let storyboard = UIStoryboard(name: "NewIssue", bundle: nil)
+
+        let viewController = storyboard.instantiateInitialViewController() as? NewIssueTableViewController
+        viewController?.hidesBottomBarWhenPushed = true
+        viewController?.client = client
+        viewController?.owner = owner
+        viewController?.repo = repo
+        viewController?.template = template
+        viewController?.signature = signature
+
+        return viewController
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -106,6 +127,7 @@ final class NewIssueTableViewController: UITableViewController, UITextFieldDeleg
         // Setup markdown input view
         bodyField.githawkConfigure(inset: false)
         setupInputView()
+        bodyField.text = template
 
         // Update title to use localization
         title = Constants.Strings.newIssue

--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -142,21 +142,16 @@ ContextMenuDelegate {
     }
 
     func newIssueAction() -> UIAlertAction? {
-        guard let newIssueViewController = NewIssueTableViewController.create(
-            client: client,
-            owner: repo.owner,
-            repo: repo.name,
-            signature: .sentWithGitHawk)
-        else {
-            Squawk.showGenericError()
-            return nil
+        let action = UIAlertAction(title: "New Issue", style: UIAlertActionStyle.default) { _ in
+            self.client.createNewIssue(
+                owner: self.repo.owner,
+                repo: self.repo.name,
+                session: nil,
+                mainViewController: self,
+                delegate: self
+            )
         }
-
-        newIssueViewController.delegate = self
-        weak var weakSelf = self
-
-        return AlertAction(AlertActionBuilder { $0.rootViewController = weakSelf })
-            .newIssue(issueController: newIssueViewController)
+        return action
     }
 
     func workingCopyAction() -> UIAlertAction? {

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -162,19 +162,17 @@ NewIssueTableViewControllerDelegate, DefaultReactionDelegate {
     }
 
     func onReportBug() {
-        guard let viewController = NewIssueTableViewController.create(
-                client: GithubClient(userSession: sessionManager.focusedUserSession),
-                owner: "GitHawkApp",
-                repo: "GitHawk",
-                signature: .bugReport
-            ) else {
-                Squawk.showGenericError()
-                return
-        }
-        viewController.delegate = self
-        let navController = UINavigationController(rootViewController: viewController)
-        navController.modalPresentationStyle = .formSheet
-        present(navController, animated: trueUnlessReduceMotionEnabled)
+        showTemplateOptions()
+    }
+
+    func showTemplateOptions() {
+        client.createNewIssue(
+            owner: "GitHawkApp",
+            repo: "GitHawk",
+            session: sessionManager.focusedUserSession,
+            mainViewController: self,
+            delegate: self
+        )
     }
 
     func onViewSource() {

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -2161,6 +2161,7 @@
 			children = (
 				98B5A0811F6C73D6000617D6 /* NewIssue.storyboard */,
 				98647DF21F758CCF00A4DE7A /* NewIssueTableViewController.swift */,
+				C0DEB1DC218E7BFB00B6FEFD /* IssueTemplates.swift */,
 			);
 			path = "New Issue";
 			sourceTree = "<group>";
@@ -2948,6 +2949,7 @@
 				29F3A18820CBFF8700645CB7 /* CreateNotificationTitle.swift in Sources */,
 				292EB08D1F1FF58D0046865D /* IssueMilestoneEventModel.swift in Sources */,
 				292EB0911F1FF72D0046865D /* IssueMilestoneEventSectionController.swift in Sources */,
+				C0DEB1DD218E7BFB00B6FEFD /* IssueTemplates.swift in Sources */,
 				DCA5ED141FAEE8030072F074 /* Bookmark.swift in Sources */,
 				299F4A89204CEDDC004BA4F0 /* Client+AccessToken.swift in Sources */,
 				2931892F1F539C0E00EF0911 /* IssueMilestoneSectionController.swift in Sources */,


### PR DESCRIPTION
Looking for preliminary feedback. I'm thinking of moving regex matching to an extension. I originally had it that the IssueTemplateHelper returned the templates to the caller and let it deal with it how it wished. I just then felt that since every view that wants to open a new issue needs to go through the same process that maybe its better to pass the view controller in and keep the code all in one place. Since it starts with an extension on the client the client isn't being passed around. 

Anyways let me know what to fix.

TODO:
- [ ] Add Spinner 
- [ ] Remove template details before passing it through (Text between the dashes ( --- ) at the beginning of a template file)