### PR TITLE
Progressive swipe (Tabbar)

### DIFF
--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -64,7 +64,7 @@ ContextMenuDelegate {
         settings.style.buttonBarItemsShouldFillAvailiableWidth = true
         settings.style.buttonBarHeight = 44
 
-        pagerBehaviour = .common(skipIntermediateViewControllers: true)
+        pagerBehaviour = .progressive(skipIntermediateViewControllers: true, elasticIndicatorLimit: true)
         changeCurrentIndex = { (oldCell, newCell, animated) in
             oldCell?.label.textColor = Styles.Colors.Gray.medium.color
             newCell?.label.textColor = Styles.Colors.Blue.medium.color


### PR DESCRIPTION
This was lost after the switch from Tabman.

Allow the tabbar indicator to move while user swipes rather than a quick jump at the end.