### PR TITLE
Better UX when switching accounts on iPad

### DIFF
--- a/Classes/Settings/SettingsAccountsViewController.swift
+++ b/Classes/Settings/SettingsAccountsViewController.swift
@@ -74,8 +74,7 @@ final class SettingsAccountsViewController: UITableViewController, GitHubSession
 
     private func finishLogin(token: String, authMethod: GitHubUserSession.AuthMethod, username: String) {
         sessionManager.focus(
-            GitHubUserSession(token: token, authMethod: authMethod, username: username),
-            dismiss: false
+            GitHubUserSession(token: token, authMethod: authMethod, username: username)
         )
     }
 
@@ -106,12 +105,12 @@ final class SettingsAccountsViewController: UITableViewController, GitHubSession
 
         let selectedSession = userSessions[indexPath.row]
         guard selectedSession != sessionManager.focusedUserSession else { return }
-        sessionManager.focus(selectedSession, dismiss: false)
+        sessionManager.focus(selectedSession)
     }
 
     // MARK: GitHubSessionListener
 
-    func didFocus(manager: GitHubSessionManager, userSession: GitHubUserSession, dismiss: Bool) {
+    func didFocus(manager: GitHubSessionManager, userSession: GitHubUserSession, isSwitch: Bool) {
         updateUserSessions()
         tableView.reloadData()
     }

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -12,10 +12,17 @@ import GitHubSession
 import Squawk
 
 final class SettingsViewController: UITableViewController,
-NewIssueTableViewControllerDelegate, DefaultReactionDelegate {
+    NewIssueTableViewControllerDelegate,
+    DefaultReactionDelegate,
+GitHubSessionListener {
 
     // must be injected
-    var sessionManager: GitHubSessionManager!
+    var sessionManager: GitHubSessionManager! {
+        didSet {
+            sessionManager.addListener(listener: self)
+        }
+    }
+
     var client: GithubClient!
 
     @IBOutlet weak var versionLabel: UILabel!
@@ -65,7 +72,7 @@ NewIssueTableViewControllerDelegate, DefaultReactionDelegate {
         updateDefaultReaction()
 
         rz_smoothlyDeselectRows(tableView: tableView)
-        accountsCell.detailTextLabel?.text = sessionManager.focusedUserSession?.username ?? Constants.Strings.unknown
+        updateActiveAccount()
 
         client.client.send(GitHubAPIStatusRequest()) { [weak self] result in
             guard let strongSelf = self else { return }
@@ -284,6 +291,10 @@ NewIssueTableViewControllerDelegate, DefaultReactionDelegate {
         showContextualMenu(PushNotificationsDisclaimerViewController())
     }
 
+    func updateActiveAccount() {
+        accountsCell.detailTextLabel?.text = sessionManager.focusedUserSession?.username ?? Constants.Strings.unknown
+    }
+
     // MARK: NewIssueTableViewControllerDelegate
 
     func didDismissAfterCreatingIssue(model: IssueDetailsModel) {
@@ -295,4 +306,13 @@ NewIssueTableViewControllerDelegate, DefaultReactionDelegate {
     func didUpdateDefaultReaction() {
         updateDefaultReaction()
     }
+
+    // MARK: GitHubSessionListener
+
+    func didFocus(manager: GitHubSessionManager, userSession: GitHubUserSession, isSwitch: Bool) {
+        updateActiveAccount()
+    }
+
+    func didLogout(manager: GitHubSessionManager) {}
+
 }

--- a/Classes/Systems/AppRouter/AppSplitViewController.swift
+++ b/Classes/Systems/AppRouter/AppSplitViewController.swift
@@ -31,12 +31,17 @@ final class AppSplitViewController: UISplitViewController {
     func resetEmpty() {
         let controller = UIViewController()
         controller.view.backgroundColor = Styles.Colors.background
-        reset(viewControllers: [UINavigationController(rootViewController: controller)])
+        reset(
+            viewControllers: [UINavigationController(rootViewController: controller)],
+            clearDetail: true
+        )
     }
 
-    func reset(viewControllers: [UIViewController]) {
+    func reset(viewControllers: [UIViewController], clearDetail: Bool) {
         masterTabBarController?.viewControllers = viewControllers
-        detailNavigationController?.viewControllers = [SplitPlaceholderViewController()]
+        if clearDetail {
+            detailNavigationController?.viewControllers = [SplitPlaceholderViewController()]
+        }
     }
 
 }

--- a/Classes/Systems/AppRouter/SwitchAccountShortcutRoute+RoutePerformable.swift
+++ b/Classes/Systems/AppRouter/SwitchAccountShortcutRoute+RoutePerformable.swift
@@ -15,7 +15,7 @@ extension SwitchAccountShortcutRoute: RoutePerformable {
         let userSessions = props.sessionManager.userSessions
         guard let needle = userSessions.first(where: { username == $0.username })
             else { return .error }
-        props.sessionManager.focus(needle, dismiss: false)
+        props.sessionManager.focus(needle)
         props.splitViewController.masterTabBarController?.selectTab(of: NotificationsViewController.self)
         return .custom
     }

--- a/Classes/Views/IssueTextActionsView+Markdown.swift
+++ b/Classes/Views/IssueTextActionsView+Markdown.swift
@@ -96,4 +96,3 @@ extension IssueTextActionsView {
     }
 
 }
-

--- a/Local Pods/GitHubSession/GitHubSession/GitHubSessionManager.swift
+++ b/Local Pods/GitHubSession/GitHubSession/GitHubSessionManager.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol GitHubSessionListener: class {
-    func didFocus(manager: GitHubSessionManager, userSession: GitHubUserSession, dismiss: Bool)
+    func didFocus(manager: GitHubSessionManager, userSession: GitHubUserSession, isSwitch: Bool)
     func didLogout(manager: GitHubSessionManager)
 }
 
@@ -83,14 +83,14 @@ public class GitHubSessionManager: NSObject {
     }
 
     public func focus(
-        _ userSession: GitHubUserSession,
-        dismiss: Bool
+        _ userSession: GitHubUserSession
         ) {
+        let isSwitch = _userSessions.count > 0
         _userSessions.remove(userSession)
         _userSessions.insert(userSession, at: 0)
         save()
         for wrapper in listeners {
-            wrapper.listener?.didFocus(manager: self, userSession: userSession, dismiss: dismiss)
+            wrapper.listener?.didFocus(manager: self, userSession: userSession, isSwitch: isSwitch)
         }
     }
 


### PR DESCRIPTION
Noticed this when testing. If you switch accounts the VCs would reset (deleting the switcher VC) and settings wouldn't change the selected account.