### PR TITLE
Fix deep links now working as expected on cold start of the app.

### DIFF
--- a/Classes/View Controllers/SplitViewControllerDelegate.swift
+++ b/Classes/View Controllers/SplitViewControllerDelegate.swift
@@ -94,7 +94,10 @@ final class SplitViewControllerDelegate: UISplitViewControllerDelegate {
         guard let tab = splitViewController.viewControllers.first as? UITabBarController
             else { return false }
 
-        if splitViewController.isCollapsed {
+        // isCollapsed can be false even when showing a single view controller on iPhone.
+        // We check viewControllers.count as well to ensure we don't skip showing view controllers on the nav stack that we'd like to.
+        // https://github.com/GitHawkApp/GitHawk/issues/2450
+        if splitViewController.isCollapsed || splitViewController.viewControllers.count == 1 {
             if let nav = vc as? UINavigationController, let first = nav.viewControllers.first {
                 tab.selectedViewController?.show(first, sender: sender)
             } else {


### PR DESCRIPTION
This change works around an issue causing deep links to not work during app sessions that were started via deep link (more details [here](https://github.com/GitHawkApp/GitHawk/issues/2450)). I found that `isCollapsed` returns `false` for the entire duration of these sessions despite `viewControllers` only containing a single view controller, which could be considered as "collapsed". Perhaps on devices where only one view controller could ever be presented UIKit doesn't update the value if `isCollapsed`.

I tested this out on iPad, where `isCollapsed` is always `false`, and on an iPhone XS Max where `isCollapsed` can actually mutate between landscape and portrait, and everything seemed to work smoothly. I'd suggest this as a fix for the issue! If you'd like me to dig deeper on the subject I can try to find out more about the nature of this issue.