### PR TITLE
remove "remove bookmarks" part of the signout message

### DIFF
--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -203,8 +203,8 @@ GitHubSessionListener {
 
     private func onSignOut() {
         let title = NSLocalizedString("Are you sure?", comment: "")
-        let message = NSLocalizedString("All of your accounts will be signed out, and their bookmarks will be removed. Do you want to continue?", comment: "")
-        let alert = UIAlertController.configured(title: title, message: message, preferredStyle: .alert)
+        let message = NSLocalizedString("You will be signed out from all of your accounts. Do you want to sign out?", comment: "")
+        let alert = UIAlertController.configured(title: title, message: message, preferredStyle: .actionSheet)
         alert.addActions([
             AlertAction.cancel(),
             AlertAction(AlertActionBuilder {


### PR DESCRIPTION
Right now the logout mentions that the bookmarks are removed during the logout process, but the `sessionManager` just signs out

fixes #2530
