### PR TITLE
switch from the now deprecated to the new status page

### DIFF
--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -82,21 +82,13 @@ GitHubSessionListener {
                 strongSelf.apiStatusView.isHidden = true
                 strongSelf.apiStatusLabel.text = NSLocalizedString("error", comment: "")
             case .success(let response):
-                let text: String
+                let text = response.data.status.description
                 let color: UIColor
                 switch response.data.status.indicator {
-                case .none:
-                    text = response.data.status.description
-                    color = Styles.Colors.Green.medium.color
-                case .minor:
-                    text = response.data.status.description
-                    color = Styles.Colors.Yellow.medium.color
-                case .major:
-                    text = response.data.status.description
-                    color = Styles.Colors.Red.medium.color
-                case .critical:
-                    text = response.data.status.description
-                    color = Styles.Colors.Red.medium.color
+                case .none: color = Styles.Colors.Green.medium.color
+                case .minor: color = Styles.Colors.Yellow.medium.color
+                case .major: color = Styles.Colors.Red.medium.color
+                case .critical: color = Styles.Colors.Red.medium.color
                 }
                 strongSelf.apiStatusView.isHidden = false
                 strongSelf.apiStatusView.backgroundColor = color

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -139,7 +139,7 @@ GitHubSessionListener {
     }
 
     private func onGitHubStatus() {
-        guard let url = URLBuilder(host: "githubstatus.com").url
+        guard let url = URLBuilder(host: "www.githubstatus.com").url
             else { return }
         presentSafari(url: url)
     }

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -88,7 +88,7 @@ GitHubSessionListener {
                 case .none: color = Styles.Colors.Green.medium.color
                 case .minor: color = Styles.Colors.Yellow.medium.color
                 case .major: color = Styles.Colors.Red.medium.color
-                case .critical: color = Styles.Colors.Red.medium.color
+                case .critical: color = Styles.Colors.Red.dark.color
                 }
                 strongSelf.apiStatusView.isHidden = false
                 strongSelf.apiStatusView.backgroundColor = color

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -84,15 +84,18 @@ GitHubSessionListener {
             case .success(let response):
                 let text: String
                 let color: UIColor
-                switch response.data.status {
-                case .good:
-                    text = NSLocalizedString("Good", comment: "")
+                switch response.data.status.indicator {
+                case .none:
+                    text = response.data.status.description
                     color = Styles.Colors.Green.medium.color
                 case .minor:
-                    text = NSLocalizedString("Minor", comment: "")
+                    text = response.data.status.description
                     color = Styles.Colors.Yellow.medium.color
                 case .major:
-                    text = NSLocalizedString("Major", comment: "")
+                    text = response.data.status.description
+                    color = Styles.Colors.Red.medium.color
+                case .critical:
+                    text = response.data.status.description
                     color = Styles.Colors.Red.medium.color
                 }
                 strongSelf.apiStatusView.isHidden = false
@@ -144,7 +147,7 @@ GitHubSessionListener {
     }
 
     private func onGitHubStatus() {
-        guard let url = URLBuilder(host: "status.github.com").add(path: "messages").url
+        guard let url = URLBuilder(host: "githubstatus.com").url
             else { return }
         presentSafari(url: url)
     }

--- a/Classes/Views/Styles.swift
+++ b/Classes/Views/Styles.swift
@@ -90,6 +90,7 @@ enum Styles {
         static let splitViewBackground = UIColor(red: 0.556863, green: 0.556863, blue: 0.576471, alpha: 1)
 
         enum Red {
+            static let dark = "75151d"
             static let medium = "cb2431"
             static let light = "ffeef0"
         }

--- a/Local Pods/GitHubAPI/GitHubAPI/GitHubAPIStatusRequest.swift
+++ b/Local Pods/GitHubAPI/GitHubAPI/GitHubAPIStatusRequest.swift
@@ -16,7 +16,7 @@ public struct Status: Codable {
     public let indicator: StatusType
     public let description: String
     
-    public enum StatusType: String,Codable, CodingKey {
+    public enum StatusType: String, Codable, CodingKey {
         case none, minor, major, critical
     }
 }

--- a/Local Pods/GitHubAPI/GitHubAPI/GitHubAPIStatusRequest.swift
+++ b/Local Pods/GitHubAPI/GitHubAPI/GitHubAPIStatusRequest.swift
@@ -9,15 +9,22 @@
 import Foundation
 
 public struct APIStatus: Codable {
-    public enum StatusType: String, Codable {
-        case good, minor, major
-    }
-    public let status: StatusType
+    public let status: Status
 }
+
+public struct Status: Codable {
+    public let indicator: StatusType
+    public let description: String
+    
+    public enum StatusType: String,Codable, CodingKey {
+        case none, minor, major, critical
+    }
+}
+
 
 public struct GitHubAPIStatusRequest: HTTPRequest {
     public typealias ResponseType = V3DataResponse<APIStatus>
-    public var url: String { return "https://status.github.com/api/status.json" }
+    public var url: String { return "https://www.githubstatus.com/api/v2/status.json" }
     public var logoutOnAuthFailure: Bool { return false }
     public var method: HTTPMethod { return .get }
     public var parameters: [String : Any]? { return nil }


### PR DESCRIPTION
the "old" status page https://status.github.com is no deprecated and GitHub switched to a statuspage.io implementation with https://githubstatus.com. The page mentions the deprecation.

This PR switches the url to the new status page and changes the status API model for the new REST- response.

The new API replaced the `good` state with the state `none`. And has more fields, that are probably 
 not relevant for the App.

Previous response:
```json
{"status":"good","last_updated":"2018-12-06T17:09:57Z"}
```

New response:
```json
{"page":{"id":"kctbh9vrtdwd","name":"GitHub","url":"https://www.githubstatus.com","time_zone":"Etc/UTC","updated_at":"2018-12-12T05:38:30.535Z"},"status":{"indicator":"none","description":"All Systems Operational"}}
```

New page in SafariVC:
![image](https://user-images.githubusercontent.com/1848357/49856241-9b574900-fdef-11e8-8805-a6c24955efef.png)


fixes: #2546 