### PR TITLE
Changing request review message to self when the same user

### DIFF
--- a/Classes/Issues/Merge/MergeButton.swift
+++ b/Classes/Issues/Merge/MergeButton.swift
@@ -37,7 +37,7 @@ final class MergeButton: UIView {
         layer.cornerRadius = Styles.Sizes.avatarCornerRadius
 
         let image = UIImage(named: "chevron-down").withRenderingMode(.alwaysTemplate)
-        let optionButtonWidth = (image.size.width ?? 0) + (2 * Styles.Sizes.gutter)
+        let optionButtonWidth = image.size.width + (2 * Styles.Sizes.gutter)
         optionIconView.contentMode = .center
         optionIconView.image = image
         optionIconView.isAccessibilityElement = true

--- a/Classes/Issues/Request/IssueRequestModel.swift
+++ b/Classes/Issues/Request/IssueRequestModel.swift
@@ -42,6 +42,63 @@ final class IssueRequestModel: ListDiffable {
         self.date = date
         self.event = event
 
+        let styledString: StyledTextString
+        if actor == user {
+            styledString = IssueRequestModel.buildSelfString(actor: actor,
+                                                             user: user,
+                                                             date: date,
+                                                             event: event)
+        } else {
+            styledString = IssueRequestModel.buildString(actor: actor,
+                                                         user: user,
+                                                         date: date,
+                                                         event: event)
+        }
+
+        self.string = StyledTextRenderer(
+            string: styledString,
+            contentSizeCategory: contentSizeCategory,
+            inset: UIEdgeInsets(
+                top: Styles.Sizes.inlineSpacing,
+                left: 0,
+                bottom: Styles.Sizes.inlineSpacing,
+                right: 0
+            )
+        ).warm(width: width)
+    }
+
+    static private func buildSelfString(actor: String,
+                                        user: String,
+                                        date: Date,
+                                        event: Event) -> StyledTextString {
+        let phrase: String
+        switch event {
+        case .assigned: phrase = NSLocalizedString(" self-assigned this", comment: "")
+        case .unassigned: phrase = NSLocalizedString(" removed their assignment", comment: "")
+        case .reviewRequested: phrase = NSLocalizedString(" self-requested a review", comment: "")
+        case .reviewRequestRemoved: phrase = NSLocalizedString(" removed their request for review", comment: "")
+        }
+
+        let builder = StyledTextBuilder(styledText: StyledText(
+            style: Styles.Text.secondary.with(foreground: Styles.Colors.Gray.medium.color)
+        ))
+            .save()
+            .add(styledText: StyledText(text: actor, style: Styles.Text.secondaryBold.with(attributes: [
+                MarkdownAttribute.username: actor,
+                .foregroundColor: Styles.Colors.Gray.dark.color
+                ])
+            ))
+            .restore()
+            .add(text: phrase)
+            .add(text: " \(date.agoString(.long))", attributes: [MarkdownAttribute.details: DateDetailsFormatter().string(from: date)])
+
+        return builder.build()
+    }
+
+    static private func buildString(actor: String,
+                                    user: String,
+                                    date: Date,
+                                    event: Event) -> StyledTextString {
         let phrase: String
         switch event {
         case .assigned: phrase = NSLocalizedString(" assigned", comment: "")
@@ -66,16 +123,7 @@ final class IssueRequestModel: ListDiffable {
             .restore()
             .add(text: " \(date.agoString(.long))", attributes: [MarkdownAttribute.details: DateDetailsFormatter().string(from: date)])
 
-        self.string = StyledTextRenderer(
-            string: builder.build(),
-            contentSizeCategory: contentSizeCategory,
-            inset: UIEdgeInsets(
-                top: Styles.Sizes.inlineSpacing,
-                left: 0,
-                bottom: Styles.Sizes.inlineSpacing,
-                right: 0
-            )
-        ).warm(width: width)
+        return builder.build()
     }
 
     // MARK: ListDiffable

--- a/Classes/Settings/DefaultReactionDetailController.swift
+++ b/Classes/Settings/DefaultReactionDetailController.swift
@@ -96,7 +96,7 @@ class DefaultReactionDetailController: UITableViewController {
 
     private func updateSections() {
         tableView.performBatchUpdates({
-            if enabledSwitch.isOn  {
+            if enabledSwitch.isOn {
                 self.tableView.insertSections(IndexSet(integer: 1), with: .top)
             } else {
                  self.tableView.deleteSections(IndexSet(integer: 1), with: .top)

--- a/Classes/Utility/NSRegularExpression+StaticString.swift
+++ b/Classes/Utility/NSRegularExpression+StaticString.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-
 extension NSRegularExpression {
 
     convenience init(_ pattern: StaticString, options: NSRegularExpression.Options = []) {


### PR DESCRIPTION
Hey guys :))

This is a simple improvement on the `IssueRequest` changing the message when the users are the same. The same message that appears on the GitHub web interface.
From:
![simulator screen shot - iphone x - 2018-12-24 at 12 22 44](https://user-images.githubusercontent.com/8292651/50401647-7233a280-0777-11e9-97fd-189d420ef47e.png)
To:
![simulator screen shot - iphone x - 2018-12-24 at 12 23 39](https://user-images.githubusercontent.com/8292651/50401651-7790ed00-0777-11e9-926c-c3a527928e79.png)

Also, some warnings removed :)