### PR TITLE
Move status.github.com to www.githubstatus.com for API Status

### DIFF
--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -146,7 +146,7 @@ GitHubSessionListener {
     }
 
     private func onGitHubStatus() {
-        guard let url = URLBuilder(host: "status.github.com").add(path: "messages").url
+        guard let url = URLBuilder(host: "www.githubstatus.com").url
             else { return }
         presentSafari(url: url)
     }

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -86,15 +86,15 @@ GitHubSessionListener {
             case .success(let response):
                 let text: String
                 let color: UIColor
-                switch response.data.status {
-                case .good:
-                    text = NSLocalizedString("Good", comment: "")
+                text = response.data.status.description
+                switch response.data.status.indicator {
+                case .normal:
                     color = Styles.Colors.Green.medium.color
                 case .minor:
-                    text = NSLocalizedString("Minor", comment: "")
                     color = Styles.Colors.Yellow.medium.color
                 case .major:
-                    text = NSLocalizedString("Major", comment: "")
+                    color = Styles.Colors.Orange.medium.color
+                case .critical:
                     color = Styles.Colors.Red.medium.color
                 }
                 strongSelf.apiStatusView.isHidden = false

--- a/Classes/Views/Styles.swift
+++ b/Classes/Views/Styles.swift
@@ -105,6 +105,11 @@ enum Styles {
             static let light = "f1f8ff"
             static let menu = "5d9cf4"
         }
+        
+        enum Orange {
+            static let medium = "fe642e"
+            static let light = "f6d8ce"
+        }
 
         enum Gray {
             static let dark = "24292e"

--- a/Local Pods/GitHubAPI/GitHubAPI/GitHubAPIStatusRequest.swift
+++ b/Local Pods/GitHubAPI/GitHubAPI/GitHubAPIStatusRequest.swift
@@ -9,15 +9,22 @@
 import Foundation
 
 public struct APIStatus: Codable {
-    public enum StatusType: String, Codable {
-        case good, minor, major
+    public let status: Status
+}
+
+public struct Status: Codable {
+    public let indicator: StatusType
+    public let description: String
+    
+    public enum StatusType: String, Codable, CodingKey {
+        case normal = "none"
+        case minor, major, critical
     }
-    public let status: StatusType
 }
 
 public struct GitHubAPIStatusRequest: HTTPRequest {
     public typealias ResponseType = V3DataResponse<APIStatus>
-    public var url: String { return "https://status.github.com/api/status.json" }
+    public var url: String { return "https://www.githubstatus.com/api/v2/status.json" }
     public var logoutOnAuthFailure: Bool { return false }
     public var method: HTTPMethod { return .get }
     public var parameters: [String : Any]? { return nil }


### PR DESCRIPTION
status.github.com/messages has been deprecated, move to githubstatus.com

Before:
<img width="699" alt="image" src="https://user-images.githubusercontent.com/5061845/50734636-bb0a4300-11dc-11e9-8246-5ea2d4b263cf.png">

After:
<img width="991" alt="image" src="https://user-images.githubusercontent.com/5061845/50734638-c5c4d800-11dc-11e9-9ac6-cf707faf1855.png">