### PR TITLE
Support rocket & eyes emojis

### DIFF
--- a/Classes/Issues/Comments/Reactions/ReactionContent+ReactionType.swift
+++ b/Classes/Issues/Comments/Reactions/ReactionContent+ReactionType.swift
@@ -17,6 +17,8 @@ extension ReactionContent {
         case .laugh: return "😄"
         case .thumbsUp, .__unknown: return "👍"
         case .thumbsDown: return "👎"
+        case .rocket: return "🚀"
+        case .eyes: return "👀"
         }
     }
 
@@ -37,6 +39,8 @@ extension String {
         case "😄": return .laugh
         case "👍": return .thumbsUp
         case "👎": return .thumbsDown
+        case "🚀": return .rocket
+        case "👀": return .eyes
         default:   return nil
         }
     }

--- a/Classes/Issues/Comments/Reactions/ReactionContent+ReactionType.swift
+++ b/Classes/Issues/Comments/Reactions/ReactionContent+ReactionType.swift
@@ -15,10 +15,11 @@ extension ReactionContent {
         case .heart: return "❤️"
         case .hooray: return "🎉"
         case .laugh: return "😄"
-        case .thumbsUp, .__unknown: return "👍"
+        case .thumbsUp: return "👍"
         case .thumbsDown: return "👎"
         case .rocket: return "🚀"
         case .eyes: return "👀"
+        case .__unknown: return "❓"
         }
     }
 

--- a/Classes/Issues/Comments/Reactions/ReactionsMenuViewController.swift
+++ b/Classes/Issues/Comments/Reactions/ReactionsMenuViewController.swift
@@ -42,13 +42,13 @@ final class ReactionsMenuViewController: UICollectionViewController,
     private let sectionedReactions: [[ReactionContent]] = [
         [
             .thumbsUp,
-            .hooray,
             .thumbsDown,
-            .heart
+            .laugh,
+            .hooray
         ],
         [
-            .laugh,
             .confused,
+            .heart,
             .rocket,
             .eyes
         ]

--- a/Classes/Issues/Comments/Reactions/ReactionsMenuViewController.swift
+++ b/Classes/Issues/Comments/Reactions/ReactionsMenuViewController.swift
@@ -38,18 +38,25 @@ final class ReactionsMenuViewController: UICollectionViewController,
 
     private let reuseIdentifier = "cell"
     private let size: CGFloat = 50
-    private let reactions: [ReactionContent] = [
-        .thumbsUp,
-        .hooray,
-        .thumbsDown,
-        .heart,
-        .laugh,
-        .confused
+
+    private let sectionedReactions: [[ReactionContent]] = [
+        [
+            .thumbsUp,
+            .hooray,
+            .thumbsDown,
+            .heart
+        ],
+        [
+            .laugh,
+            .confused,
+            .rocket,
+            .eyes
+        ]
     ]
 
     var selectedReaction: ReactionContent? {
-        guard let item = collectionView?.indexPathsForSelectedItems?.first?.item else { return nil }
-        return reactions[item]
+        guard let item = collectionView?.indexPathsForSelectedItems?.first else { return nil }
+        return sectionedReactions[item.section][item.item]
     }
 
     init() {
@@ -69,22 +76,27 @@ final class ReactionsMenuViewController: UICollectionViewController,
         collectionView?.register(EmojiCell.self, forCellWithReuseIdentifier: reuseIdentifier)
         collectionView?.reloadData()
         collectionView?.layoutIfNeeded()
+        let reactionsInRow = sectionedReactions.first?.count ?? 0
         preferredContentSize = CGSize(
-            width: size * CGFloat(reactions.count),
-            height: size
+            width: size * CGFloat(reactionsInRow),
+            height: size * CGFloat(sectionedReactions.count)
         )
     }
 
     // MARK: UICollectionViewDataSource
 
+    override func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return sectionedReactions.count
+    }
+
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return reactions.count
+        return sectionedReactions[section].count
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
         if let cell = cell as? EmojiCell {
-            cell.label.text = reactions[indexPath.item].emoji
+            cell.label.text = sectionedReactions[indexPath.section][indexPath.item].emoji
         }
         return cell
     }

--- a/Classes/Issues/Comments/Reactions/ReactionsMenuViewController.swift
+++ b/Classes/Issues/Comments/Reactions/ReactionsMenuViewController.swift
@@ -76,7 +76,10 @@ final class ReactionsMenuViewController: UICollectionViewController,
         collectionView?.register(EmojiCell.self, forCellWithReuseIdentifier: reuseIdentifier)
         collectionView?.reloadData()
         collectionView?.layoutIfNeeded()
-        let reactionsInRow = sectionedReactions.first?.count ?? 0
+        guard let reactionsInRow = sectionedReactions.first?.count else {
+            assertionFailure("Reactions in grid row must be >0")
+            return
+        }
         preferredContentSize = CGSize(
             width: size * CGFloat(reactionsInRow),
             height: size * CGFloat(sectionedReactions.count)

--- a/Classes/Issues/Comments/Reactions/UIMenuController+Reactions.swift
+++ b/Classes/Issues/Comments/Reactions/UIMenuController+Reactions.swift
@@ -18,7 +18,9 @@ extension UIMenuController {
             .thumbsDown,
             .heart,
             .laugh,
-            .confused
+            .confused,
+            .rocket,
+            .eyes
         ]
 
         menuItems = reactions.map {

--- a/Classes/Settings/DefaultReactionDetailController.swift
+++ b/Classes/Settings/DefaultReactionDetailController.swift
@@ -20,7 +20,13 @@ class DefaultReactionDetailController: UITableViewController {
     @IBOutlet var hoorayCell: UITableViewCell!
     @IBOutlet var confusedCell: UITableViewCell!
     @IBOutlet var heartCell: UITableViewCell!
+    @IBOutlet var rocketCell: UITableViewCell!
+    @IBOutlet var eyesCell: UITableViewCell!
     @IBOutlet var enabledSwitch: UISwitch!
+
+    private var allEmojiCells: [UITableViewCell] {
+        return [thumbsUpCell, thumbsDownCell, laughCell, hoorayCell, confusedCell, heartCell, rocketCell, eyesCell]
+    }
 
     weak var delegate: DefaultReactionDelegate?
 
@@ -45,6 +51,8 @@ class DefaultReactionDetailController: UITableViewController {
         case hoorayCell: updateDefault(reaction: .hooray)
         case confusedCell: updateDefault(reaction: .confused)
         case heartCell: updateDefault(reaction: .heart)
+        case rocketCell: updateDefault(reaction: .rocket)
+        case eyesCell: updateDefault(reaction: .eyes)
         default: break
         }
     }
@@ -69,6 +77,8 @@ class DefaultReactionDetailController: UITableViewController {
         case .hooray: cell = hoorayCell
         case .confused: cell = confusedCell
         case .heart: cell = heartCell
+        case .rocket: cell = rocketCell
+        case .eyes: cell = eyesCell
         }
         updateCells(cell: cell)
     }
@@ -77,7 +87,7 @@ class DefaultReactionDetailController: UITableViewController {
         rz_smoothlyDeselectRows(tableView: self.tableView)
 
         // Reset all to none
-        [thumbsUpCell, thumbsDownCell, laughCell, hoorayCell, confusedCell, heartCell].forEach { $0.accessoryType = .none }
+        allEmojiCells.forEach { $0.accessoryType = .none }
 
         // Set proper cell to check
         cell.accessoryType = .checkmark

--- a/Classes/Settings/Settings.storyboard
+++ b/Classes/Settings/Settings.storyboard
@@ -638,6 +638,40 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="9Ah-c8-z8e" style="IBUITableViewCellStyleDefault" id="tzi-sg-G24" customClass="StyledTableCell" customModule="Freetime" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="406.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tzi-sg-G24" id="QXI-y4-j4s">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="🚀 Rocket" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9Ah-c8-z8e" customClass="SettingsLabel" customModule="Freetime" customModuleProvider="target">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.14117647059999999" green="0.16078431369999999" blue="0.18039215689999999" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="bDW-Nk-KQZ" style="IBUITableViewCellStyleDefault" id="Ew9-wr-LdI" customClass="StyledTableCell" customModule="Freetime" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="450.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ew9-wr-LdI" id="fWy-M3-O88">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="👀 Eyes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bDW-Nk-KQZ" customClass="SettingsLabel" customModule="Freetime" customModuleProvider="target">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.14117647059999999" green="0.16078431369999999" blue="0.18039215689999999" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -650,9 +684,11 @@
                     <connections>
                         <outlet property="confusedCell" destination="X0F-M1-kZ7" id="bvF-iv-PVz"/>
                         <outlet property="enabledSwitch" destination="Dj7-Q0-qBc" id="UlX-Jw-KJM"/>
+                        <outlet property="eyesCell" destination="Ew9-wr-LdI" id="gS1-el-uUr"/>
                         <outlet property="heartCell" destination="lKi-qn-1Lw" id="c6c-gg-fqo"/>
                         <outlet property="hoorayCell" destination="NBn-uY-24s" id="90x-RY-v8E"/>
                         <outlet property="laughCell" destination="jkZ-Ag-Uss" id="ooc-D4-RUk"/>
+                        <outlet property="rocketCell" destination="tzi-sg-G24" id="jwi-cf-UW2"/>
                         <outlet property="thumbsDownCell" destination="ISD-qw-50W" id="dcM-3X-5h9"/>
                         <outlet property="thumbsUpCell" destination="qc4-aU-1zn" id="yoU-W7-RdX"/>
                     </connections>

--- a/gql/API.swift
+++ b/gql/API.swift
@@ -17,6 +17,10 @@ public enum ReactionContent: RawRepresentable, Equatable, Apollo.JSONDecodable, 
   case confused
   /// Represents the ❤️ emoji.
   case heart
+  /// Represents the 🚀 emoji.
+  case rocket
+  /// Represents the 👀 emoji.
+  case eyes
   /// Auto generated constant for unknown enum values
   case __unknown(RawValue)
 
@@ -28,6 +32,8 @@ public enum ReactionContent: RawRepresentable, Equatable, Apollo.JSONDecodable, 
       case "HOORAY": self = .hooray
       case "CONFUSED": self = .confused
       case "HEART": self = .heart
+      case "ROCKET": self = .rocket
+      case "EYES": self = .eyes
       default: self = .__unknown(rawValue)
     }
   }
@@ -40,6 +46,8 @@ public enum ReactionContent: RawRepresentable, Equatable, Apollo.JSONDecodable, 
       case .hooray: return "HOORAY"
       case .confused: return "CONFUSED"
       case .heart: return "HEART"
+      case .rocket: return "ROCKET"
+      case .eyes: return "EYES"
       case .__unknown(let value): return value
     }
   }
@@ -52,6 +60,8 @@ public enum ReactionContent: RawRepresentable, Equatable, Apollo.JSONDecodable, 
       case (.hooray, .hooray): return true
       case (.confused, .confused): return true
       case (.heart, .heart): return true
+      case (.rocket, .rocket): return true
+      case (.eyes, .eyes): return true
       case (.__unknown(let lhsValue), .__unknown(let rhsValue)): return lhsValue == rhsValue
       default: return false
     }

--- a/gql/schema.json
+++ b/gql/schema.json
@@ -17652,6 +17652,18 @@
               "description": "Represents the ❤️ emoji.",
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "ROCKET",
+              "description": "Represents the 🚀 emoji.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EYES",
+              "description": "Represents the 👀 emoji.",
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null


### PR DESCRIPTION
Closes #2605

Added two new emojis to GQL schema, emoji picker & default emoji selection screens. Moreover, split emoji picker cells into two rows, though the order of them is not preserved from Github Web UI.

|![simulator screen shot - iphone xr - 2019-01-20 at 11 13 14](https://user-images.githubusercontent.com/3721061/51437319-63240f80-1ca5-11e9-98c4-64de9a18abb1.png)|
![simulator screen shot - iphone xr - 2019-01-20 at 11 19 40](https://user-images.githubusercontent.com/3721061/51437320-6cad7780-1ca5-11e9-9fc5-fe955989d1ab.png)|
|-|-|

1. Unknown emojis are still defaulted to 👍 , not which approach is better and if it's worth solving that at all;
2. Static UITableView for default emoji selection is a bit repetitive now, I suggest making dynamic list either as part of this PR or as a separate. Any thoughts?