### PR TITLE
Pagination for repo branches list

### DIFF
--- a/Classes/Repository/RepositoryBranches/GitHubClient+RepositoryBranches.swift
+++ b/Classes/Repository/RepositoryBranches/GitHubClient+RepositoryBranches.swift
@@ -7,31 +7,54 @@
 //
 
 import GitHubAPI
+import Apollo
+
+private extension FetchRepositoryBranchesQuery.Data {
+
+    func branches() -> [String] {
+        var branches: [String] = []
+        repository?.refs.map { edges in
+            edges.edges.map { edge in
+                branches += edge.compactMap {
+                    $0?.node?.name
+                }
+            }
+        }
+        return branches
+    }
+
+    func nextPageToken() -> String? {
+        guard repository?.refs?.pageInfo.hasNextPage == true else { return nil }
+        return repository?.refs?.pageInfo.endCursor
+    }
+
+}
 
 extension GithubClient {
 
+    struct RepositoryBranchesPayload {
+        let branches: [String]
+        let nextPage: String?
+    }
+
     func fetchRepositoryBranches(owner: String,
                                  repo: String,
-                                 completion: @escaping (Result<([String])>) -> Void
+                                 nextPage: String?,
+                                 completion: @escaping (Result<RepositoryBranchesPayload>) -> Void
     ) {
-        let query = FetchRepositoryBranchesQuery(owner: owner, name: repo)
-        client.query(query, result: { $0.repository }, completion: { result in
+        let query = FetchRepositoryBranchesQuery(owner: owner, name: repo, after: nextPage)
+        client.query(query, result: { $0 }, completion: { result in
 
         switch result {
         case .failure(let error):
                 completion(.error(error))
 
-        case .success(let repository):
-            var branches: [String] = []
-            repository.refs.map { edges in
-                edges.edges.map { edge in
-                    branches += edge.compactMap {
-                        $0?.node?.name
-                    }
-                }
-            }
-
-            completion(.success(branches))
+        case .success(let data):
+            let payload = RepositoryBranchesPayload(
+                branches: data.branches(),
+                nextPage: data.nextPageToken()
+            )
+            completion(.success(payload))
             }
         })
     }

--- a/Classes/Repository/RepositoryBranches/RepositoryBranchesViewController.swift
+++ b/Classes/Repository/RepositoryBranches/RepositoryBranchesViewController.swift
@@ -69,22 +69,24 @@ RepositoryBranchSectionControllerDelegate {
     }
 
     override func fetch(page: String?) {
-        client.fetchRepositoryBranches(owner: owner,
-                                 repo: repo
-            ) {  [weak self] result in
+        client.fetchRepositoryBranches(
+            owner: owner,
+            repo: repo,
+            nextPage: page as String?
+        ) {  [weak self] result in
             guard let strongSelf = self else { return }
             switch result {
-            case .success(let branches):
+            case .success(let payload):
                 self?.branches = RepositoryBranchesViewController.arrangeBranches(
                     selectedBranch: strongSelf.selectedBranch,
                     defaultBranch: strongSelf.defaultBranch,
-                    branches: branches
+                    branches: strongSelf.branches + payload.branches
                 )
-
+                self?.update(page: payload.nextPage, animated: true)
             case .error(let error):
                 Squawk.show(error: error)
+                self?.error(animated: trueUnlessReduceMotionEnabled)
             }
-            self?.update(animated: true)
         }
     }
 

--- a/Classes/Repository/RepositoryBranches/RepositoryBranchesViewController.swift
+++ b/Classes/Repository/RepositoryBranches/RepositoryBranchesViewController.swift
@@ -77,15 +77,15 @@ RepositoryBranchSectionControllerDelegate {
             guard let strongSelf = self else { return }
             switch result {
             case .success(let payload):
-                self?.branches = RepositoryBranchesViewController.arrangeBranches(
+                strongSelf.branches = RepositoryBranchesViewController.arrangeBranches(
                     selectedBranch: strongSelf.selectedBranch,
                     defaultBranch: strongSelf.defaultBranch,
                     branches: strongSelf.branches + payload.branches
                 )
-                self?.update(page: payload.nextPage, animated: true)
+                strongSelf.update(page: payload.nextPage, animated: true)
             case .error(let error):
                 Squawk.show(error: error)
-                self?.error(animated: trueUnlessReduceMotionEnabled)
+                strongSelf.error(animated: trueUnlessReduceMotionEnabled)
             }
         }
     }

--- a/gql/API.swift
+++ b/gql/API.swift
@@ -14888,18 +14888,20 @@ public final class RemoveReactionMutation: GraphQLMutation {
 
 public final class FetchRepositoryBranchesQuery: GraphQLQuery {
   public static let operationString =
-    "query fetchRepositoryBranches($owner: String!, $name: String!) {\n  repository(owner: $owner, name: $name) {\n    __typename\n    refs(first: 50, refPrefix: \"refs/heads/\") {\n      __typename\n      edges {\n        __typename\n        node {\n          __typename\n          name\n        }\n      }\n    }\n  }\n}"
+    "query fetchRepositoryBranches($owner: String!, $name: String!, $after: String) {\n  repository(owner: $owner, name: $name) {\n    __typename\n    refs(first: 50, after: $after, refPrefix: \"refs/heads/\") {\n      __typename\n      edges {\n        __typename\n        node {\n          __typename\n          name\n        }\n      }\n      pageInfo {\n        __typename\n        hasNextPage\n        endCursor\n      }\n    }\n  }\n}"
 
   public var owner: String
   public var name: String
+  public var after: String?
 
-  public init(owner: String, name: String) {
+  public init(owner: String, name: String, after: String? = nil) {
     self.owner = owner
     self.name = name
+    self.after = after
   }
 
   public var variables: GraphQLMap? {
-    return ["owner": owner, "name": name]
+    return ["owner": owner, "name": name, "after": after]
   }
 
   public struct Data: GraphQLSelectionSet {
@@ -14934,7 +14936,7 @@ public final class FetchRepositoryBranchesQuery: GraphQLQuery {
 
       public static let selections: [GraphQLSelection] = [
         GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("refs", arguments: ["first": 50, "refPrefix": "refs/heads/"], type: .object(Ref.selections)),
+        GraphQLField("refs", arguments: ["first": 50, "after": GraphQLVariable("after"), "refPrefix": "refs/heads/"], type: .object(Ref.selections)),
       ]
 
       public var snapshot: Snapshot
@@ -14972,6 +14974,7 @@ public final class FetchRepositoryBranchesQuery: GraphQLQuery {
         public static let selections: [GraphQLSelection] = [
           GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
           GraphQLField("edges", type: .list(.object(Edge.selections))),
+          GraphQLField("pageInfo", type: .nonNull(.object(PageInfo.selections))),
         ]
 
         public var snapshot: Snapshot
@@ -14980,8 +14983,8 @@ public final class FetchRepositoryBranchesQuery: GraphQLQuery {
           self.snapshot = snapshot
         }
 
-        public init(edges: [Edge?]? = nil) {
-          self.init(snapshot: ["__typename": "RefConnection", "edges": edges.flatMap { (value: [Edge?]) -> [Snapshot?] in value.map { (value: Edge?) -> Snapshot? in value.flatMap { (value: Edge) -> Snapshot in value.snapshot } } }])
+        public init(edges: [Edge?]? = nil, pageInfo: PageInfo) {
+          self.init(snapshot: ["__typename": "RefConnection", "edges": edges.flatMap { (value: [Edge?]) -> [Snapshot?] in value.map { (value: Edge?) -> Snapshot? in value.flatMap { (value: Edge) -> Snapshot in value.snapshot } } }, "pageInfo": pageInfo.snapshot])
         }
 
         public var __typename: String {
@@ -15000,6 +15003,16 @@ public final class FetchRepositoryBranchesQuery: GraphQLQuery {
           }
           set {
             snapshot.updateValue(newValue.flatMap { (value: [Edge?]) -> [Snapshot?] in value.map { (value: Edge?) -> Snapshot? in value.flatMap { (value: Edge) -> Snapshot in value.snapshot } } }, forKey: "edges")
+          }
+        }
+
+        /// Information to aid in pagination.
+        public var pageInfo: PageInfo {
+          get {
+            return PageInfo(snapshot: snapshot["pageInfo"]! as! Snapshot)
+          }
+          set {
+            snapshot.updateValue(newValue.snapshot, forKey: "pageInfo")
           }
         }
 
@@ -15075,6 +15088,55 @@ public final class FetchRepositoryBranchesQuery: GraphQLQuery {
               set {
                 snapshot.updateValue(newValue, forKey: "name")
               }
+            }
+          }
+        }
+
+        public struct PageInfo: GraphQLSelectionSet {
+          public static let possibleTypes = ["PageInfo"]
+
+          public static let selections: [GraphQLSelection] = [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("hasNextPage", type: .nonNull(.scalar(Bool.self))),
+            GraphQLField("endCursor", type: .scalar(String.self)),
+          ]
+
+          public var snapshot: Snapshot
+
+          public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+          }
+
+          public init(hasNextPage: Bool, endCursor: String? = nil) {
+            self.init(snapshot: ["__typename": "PageInfo", "hasNextPage": hasNextPage, "endCursor": endCursor])
+          }
+
+          public var __typename: String {
+            get {
+              return snapshot["__typename"]! as! String
+            }
+            set {
+              snapshot.updateValue(newValue, forKey: "__typename")
+            }
+          }
+
+          /// When paginating forwards, are there more items?
+          public var hasNextPage: Bool {
+            get {
+              return snapshot["hasNextPage"]! as! Bool
+            }
+            set {
+              snapshot.updateValue(newValue, forKey: "hasNextPage")
+            }
+          }
+
+          /// When paginating forwards, the cursor to continue.
+          public var endCursor: String? {
+            get {
+              return snapshot["endCursor"] as? String
+            }
+            set {
+              snapshot.updateValue(newValue, forKey: "endCursor")
             }
           }
         }

--- a/gql/RepoBranches.graphql
+++ b/gql/RepoBranches.graphql
@@ -1,10 +1,14 @@
-query fetchRepositoryBranches($owner:String!, $name:String!) {
+query fetchRepositoryBranches($owner:String!, $name:String!, $after: String) {
     repository(owner: $owner, name: $name) {
-        refs(first: 50, refPrefix:"refs/heads/") {
+        refs(first: 50, after: $after, refPrefix:"refs/heads/") {
             edges {
                 node {
                     name
                 }
+            }
+            pageInfo {
+                hasNextPage
+                endCursor
             }
         }
     }


### PR DESCRIPTION
Closes (#2587)

Possibly quite an edge case to have more than 50 branches but it was fun working w/ GQL and pagination implementation here 🎆 

Follows pagination convention from `RepositoryIssuesViewController.swift` & `RepositoryClient.swift`, though I didn't understand why `RepoSearchPagesQuery` conforms to `RepositoryQuery` protocol instead of having extension for `RepoSearchPagesQuery.Data`.

|![simulator screen shot - iphone xr - 2019-01-21 at 14 33 59](https://user-images.githubusercontent.com/3721061/51474991-c0918c80-1d89-11e9-9ce0-3ab69e0cd0e2.png)|
|-|