### PR TITLE
Adds sound option so device can vibrate and ring

### DIFF
--- a/Classes/Systems/BadgeNotifications.swift
+++ b/Classes/Systems/BadgeNotifications.swift
@@ -63,6 +63,7 @@ final class BadgeNotifications {
         }
         if isLocalNotificationEnabled {
             options.insert(.alert)
+            options.insert(.sound)
         }
 
         if !options.isEmpty {


### PR DESCRIPTION
I was wondering why I never have any sound / vibration on notifications, while this is pleasant, we can let the user configure it in the notifications settings.