### PR TITLE
Show discard or keep alert after tapping outside of the PR reviewers,…

### DIFF
--- a/Classes/Labels/LabelsViewController.swift
+++ b/Classes/Labels/LabelsViewController.swift
@@ -19,6 +19,8 @@ LabelSectionControllerDelegate {
     private let client: GithubClient
     private let request: RepositoryLabelsQuery
 
+    var wasDismissedByDone: Bool = false
+
     init(
         selected: [RepositoryLabel],
         client: GithubClient,
@@ -100,6 +102,11 @@ LabelSectionControllerDelegate {
                 Squawk.show(error: error)
             }
         })
+    }
+
+    override func onMenuDone() {
+        self.wasDismissedByDone = true
+        super.onMenuDone()
     }
 
     // MARK: BaseListViewControllerDataSource

--- a/Classes/Milestones/MilestonesViewController.swift
+++ b/Classes/Milestones/MilestonesViewController.swift
@@ -26,6 +26,8 @@ MilestoneSectionControllerDelegate {
     private let feedRefresh = FeedRefresh()
     private var milestones = [Milestone]()
 
+    var wasDismissedByDone: Bool = false
+
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .long
@@ -94,6 +96,11 @@ MilestoneSectionControllerDelegate {
             }
             self?.update(animated: true)
         }
+    }
+
+    override func onMenuDone() {
+        self.wasDismissedByDone = true
+        super.onMenuDone()
     }
 
     // MARK: BaseListViewControllerDataSource

--- a/Classes/People/PeopleViewController.swift
+++ b/Classes/People/PeopleViewController.swift
@@ -30,6 +30,8 @@ PeopleSectionControllerDelegate {
     private var owner: String
     private var repo: String
 
+    var wasDismissedByDone: Bool = false
+
     init(
         selections: [String],
         exclusions: [String],
@@ -163,6 +165,11 @@ PeopleSectionControllerDelegate {
                 Squawk.show(error: error)
             }
         }
+    }
+
+    @objc override func onMenuDone() {
+        self.wasDismissedByDone = true
+        super.onMenuDone()
     }
 
     // MARK: BaseListViewControllerDataSource

--- a/Classes/Utility/AlertAction.swift
+++ b/Classes/Utility/AlertAction.swift
@@ -113,6 +113,10 @@ struct AlertAction {
         return UIAlertAction(title: NSLocalizedString("Discard", comment: ""), style: .destructive, handler: handler)
     }
 
+    static func keep(_ handler: AlertActionBlock? = nil) -> UIAlertAction {
+        return UIAlertAction(title: NSLocalizedString("Keep", comment: ""), style: .default, handler: handler)
+    }
+
     static func delete(_ handler: AlertActionBlock? = nil) -> UIAlertAction {
         return UIAlertAction(title: NSLocalizedString("Delete", comment: ""), style: .destructive, handler: handler)
     }


### PR DESCRIPTION
… assignees, milestones, labels modal

This my first contribution to GitHawk :) Thanks for the awesome project!

I implemented the feature from #2582. Now after tapping outside the modal for PR reviewers, assignees, milestone or labels, an alert appears asking to keep or discard the changes, if any.