### PR TITLE
Improve event spacing to give better context

### DIFF
--- a/Classes/Issues/Renamed/IssueRenamedCell.swift
+++ b/Classes/Issues/Renamed/IssueRenamedCell.swift
@@ -17,7 +17,7 @@ protocol IssueRenamedCellDelegate: class {
 final class IssueRenamedCell: UICollectionViewCell {
 
     static let titleInset = UIEdgeInsets(
-        top: Styles.Sizes.labelEventHeight,
+        top: Styles.Sizes.labelEventHeight - Styles.Sizes.rowSpacing,
         left: 0,
         bottom: Styles.Sizes.rowSpacing,
         right: 0
@@ -47,7 +47,6 @@ final class IssueRenamedCell: UICollectionViewCell {
             make.left.equalTo(actorLabel.snp.right).offset(Styles.Sizes.inlineSpacing)
             make.centerY.equalTo(actorLabel)
         }
-
         contentView.addSubview(titleView)
     }
 


### PR DESCRIPTION
As I understand it, the problem is specific to `IssueRenamedCell`. I adjusted the indent between the button and text view. 
 
![Artboard@3x](https://user-images.githubusercontent.com/35783149/54075957-59d31e80-42b6-11e9-89c7-ee221e840391.png)
