### PR TITLE
Fix for "Disallow Empty Bug Reports" Issue #2615

### DIFF
--- a/Classes/Systems/Squawk+GitHawk.swift
+++ b/Classes/Systems/Squawk+GitHawk.swift
@@ -83,4 +83,9 @@ extension Squawk {
         triggerHaptic()
     }
 
+    static func showIssueError(message: String, view: UIView?) {
+        Squawk.shared.show(in: view, config: errorConfig(text: message))
+        triggerHaptic()
+    }
+
 }


### PR DESCRIPTION
Added new function in Squawk+GitHawk.swift, showIssueError, to handle error reporting through Squawk. The previous handling would display the error beneath the keyboard, on this form, and not be seen. Not that this should ever be seen.

Added a function in NewIssueTableViewController.swift that checks both the UITextField and the UITextView for content before enabling the Submit button. After the Submit button is enabled and used, we will check once again to verify content, throwing visible errors via Squawk in the TextView if no text is present, before sending.