### PR TITLE
Fix for "Accessibility “bullets hollow” should be “more options” #2673

### DIFF
--- a/Classes/Repository/RepositoryCodeBlobViewController.swift
+++ b/Classes/Repository/RepositoryCodeBlobViewController.swift
@@ -30,7 +30,7 @@ final class RepositoryCodeBlobViewController: UIViewController, EmptyViewDelegat
             target: self,
             action: #selector(RepositoryCodeBlobViewController.onShare(sender:))
         )
-        barButtonItem.accessibilityLabel =  Constants.Strings.moreOptions
+        barButtonItem.accessibilityLabel = Constants.Strings.moreOptions
         return barButtonItem
     }()
 

--- a/Classes/Repository/RepositoryCodeBlobViewController.swift
+++ b/Classes/Repository/RepositoryCodeBlobViewController.swift
@@ -26,7 +26,7 @@ final class RepositoryCodeBlobViewController: UIViewController, EmptyViewDelegat
 
     private lazy var moreOptionsItem: UIBarButtonItem = {
         let barButtonItem = UIBarButtonItem(
-            image: UIImage(named: "bullets-hollow"),
+            image: UIImage(named: "chevron-down"),
             target: self,
             action: #selector(RepositoryCodeBlobViewController.onShare(sender:))
         )

--- a/Classes/Repository/RepositoryCodeBlobViewController.swift
+++ b/Classes/Repository/RepositoryCodeBlobViewController.swift
@@ -26,7 +26,7 @@ final class RepositoryCodeBlobViewController: UIViewController, EmptyViewDelegat
 
     private lazy var moreOptionsItem: UIBarButtonItem = {
         let barButtonItem = UIBarButtonItem(
-            image: UIImage(named: "chevron-down"),
+            image: UIImage(named: "bullets-hollow"),
             target: self,
             action: #selector(RepositoryCodeBlobViewController.onShare(sender:))
         )

--- a/Classes/Repository/RepositoryCodeBlobViewController.swift
+++ b/Classes/Repository/RepositoryCodeBlobViewController.swift
@@ -30,6 +30,7 @@ final class RepositoryCodeBlobViewController: UIViewController, EmptyViewDelegat
             target: self,
             action: #selector(RepositoryCodeBlobViewController.onShare(sender:))
         )
+        barButtonItem.accessibilityLabel =  Constants.Strings.moreOptions
         return barButtonItem
     }()
 

--- a/Classes/Repository/RepositoryCodeDirectoryViewController.swift
+++ b/Classes/Repository/RepositoryCodeDirectoryViewController.swift
@@ -32,7 +32,7 @@ IndicatorInfoProvider {
     }
     private lazy var moreOptionsItem: UIBarButtonItem = {
         let barButtonItem = UIBarButtonItem(
-            image: UIImage(named: "chevron-down"),
+            image: UIImage(named: "bullets-hollow"),
             target: self,
             action: #selector(RepositoryCodeDirectoryViewController.onShare(sender:)))
         barButtonItem.isEnabled = false

--- a/Classes/Repository/RepositoryCodeDirectoryViewController.swift
+++ b/Classes/Repository/RepositoryCodeDirectoryViewController.swift
@@ -32,7 +32,7 @@ IndicatorInfoProvider {
     }
     private lazy var moreOptionsItem: UIBarButtonItem = {
         let barButtonItem = UIBarButtonItem(
-            image: UIImage(named: "bullets-hollow"),
+            image: UIImage(named: "chevron-down"),
             target: self,
             action: #selector(RepositoryCodeDirectoryViewController.onShare(sender:)))
         barButtonItem.isEnabled = false

--- a/Classes/Repository/RepositoryCodeDirectoryViewController.swift
+++ b/Classes/Repository/RepositoryCodeDirectoryViewController.swift
@@ -35,6 +35,7 @@ IndicatorInfoProvider {
             image: UIImage(named: "bullets-hollow"),
             target: self,
             action: #selector(RepositoryCodeDirectoryViewController.onShare(sender:)))
+        barButtonItem.accessibilityLabel =  Constants.Strings.moreOptions
         barButtonItem.isEnabled = false
         return barButtonItem
     }()

--- a/Classes/Repository/RepositoryCodeDirectoryViewController.swift
+++ b/Classes/Repository/RepositoryCodeDirectoryViewController.swift
@@ -35,7 +35,7 @@ IndicatorInfoProvider {
             image: UIImage(named: "bullets-hollow"),
             target: self,
             action: #selector(RepositoryCodeDirectoryViewController.onShare(sender:)))
-        barButtonItem.accessibilityLabel =  Constants.Strings.moreOptions
+        barButtonItem.accessibilityLabel = Constants.Strings.moreOptions
         barButtonItem.isEnabled = false
         return barButtonItem
     }()

--- a/Classes/Repository/RepositoryImageViewController.swift
+++ b/Classes/Repository/RepositoryImageViewController.swift
@@ -35,7 +35,7 @@ UIScrollViewDelegate {
 
     private lazy var moreOptionsItem: UIBarButtonItem = {
         let barButtonItem = UIBarButtonItem(
-            image: UIImage(named: "bullets-hollow"),
+            image: UIImage(named: "chevron-down"),
             target: self,
             action: #selector(RepositoryImageViewController.onShare(sender:)))
         barButtonItem.isEnabled = false

--- a/Classes/Repository/RepositoryImageViewController.swift
+++ b/Classes/Repository/RepositoryImageViewController.swift
@@ -38,6 +38,7 @@ UIScrollViewDelegate {
             image: UIImage(named: "bullets-hollow"),
             target: self,
             action: #selector(RepositoryImageViewController.onShare(sender:)))
+        barButtonItem.accessibilityLabel =  Constants.Strings.moreOptions
         barButtonItem.isEnabled = false
         return barButtonItem
     }()

--- a/Classes/Repository/RepositoryImageViewController.swift
+++ b/Classes/Repository/RepositoryImageViewController.swift
@@ -35,7 +35,7 @@ UIScrollViewDelegate {
 
     private lazy var moreOptionsItem: UIBarButtonItem = {
         let barButtonItem = UIBarButtonItem(
-            image: UIImage(named: "chevron-down"),
+            image: UIImage(named: "bullets-hollow"),
             target: self,
             action: #selector(RepositoryImageViewController.onShare(sender:)))
         barButtonItem.isEnabled = false

--- a/Classes/Repository/RepositoryImageViewController.swift
+++ b/Classes/Repository/RepositoryImageViewController.swift
@@ -38,7 +38,7 @@ UIScrollViewDelegate {
             image: UIImage(named: "bullets-hollow"),
             target: self,
             action: #selector(RepositoryImageViewController.onShare(sender:)))
-        barButtonItem.accessibilityLabel =  Constants.Strings.moreOptions
+        barButtonItem.accessibilityLabel = Constants.Strings.moreOptions
         barButtonItem.isEnabled = false
         return barButtonItem
     }()

--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -104,7 +104,7 @@ EmptyViewDelegate {
 
     private func updateRightBarItems() {
         let moreItem = UIBarButtonItem(
-            image: UIImage(named: "chevron-down"),
+            image: UIImage(named: "bullets-hollow"),
             target: self,
             action: #selector(RepositoryViewController.onMore(sender:))
         )

--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -104,7 +104,7 @@ EmptyViewDelegate {
 
     private func updateRightBarItems() {
         let moreItem = UIBarButtonItem(
-            image: UIImage(named: "bullets-hollow"),
+            image: UIImage(named: "chevron-down"),
             target: self,
             action: #selector(RepositoryViewController.onMore(sender:))
         )


### PR DESCRIPTION
Changed all occurrences of "bullets-hollow" to "chevron-down" to be consistent with the "More Options" button image used in MergeButton.swift

Closes #2673 