### PR TITLE
Fix notification bug

### DIFF
--- a/Classes/Systems/AppRouter/AppController.swift
+++ b/Classes/Systems/AppRouter/AppController.swift
@@ -33,6 +33,10 @@ RouterPropsSource {
         sessionManager.addListener(listener: self)
     }
 
+    func getAppClient() -> GithubClient? {
+        return self.appClient
+    }
+    
     func appDidFinishLaunching(with window: UIWindow?) {
         guard let controller = window?.rootViewController as? AppSplitViewController else {
             fatalError("App must be setup with a split view controller")


### PR DESCRIPTION
Closes #2298

@BasThomas let me know if this makes sense. 

Issue:
Tapping notification to open issue doesn't mark the notification read

Solution:
Notification ID is passed apart of the request when creating local notification. Before routing to the Issue, extract the ID and mark the notification as read. 

We are marking notifications are read before actually displaying the notification but this no different than how it works when tapping on a note. in the inbox.  

Possible enhancement:
We have some redundant code here. The `markNotificationRead` method shows up here and in `NotificationModelController` suggestions are welcome as to where the best place to put it is. Keep in mind if we refactor both methods we will need to pass in the `GithubClient` which isn't great.