### PR TITLE
Fix scroll indicator styles in menus

### DIFF
--- a/Classes/Labels/LabelsViewController.swift
+++ b/Classes/Labels/LabelsViewController.swift
@@ -32,6 +32,7 @@ LabelSectionControllerDelegate {
         preferredContentSize = Styles.Sizes.contextMenuSize
         title = Constants.Strings.labels
         feed.collectionView.backgroundColor = Styles.Colors.menuBackgroundColor.color
+        feed.collectionView.indicatorStyle = .white
         feed.setLoadingSpinnerColor(to: .white)
         dataSource = self
     }

--- a/Classes/Milestones/MilestonesViewController.swift
+++ b/Classes/Milestones/MilestonesViewController.swift
@@ -47,6 +47,7 @@ MilestoneSectionControllerDelegate {
         title = Constants.Strings.milestone
         preferredContentSize = Styles.Sizes.contextMenuSize
         feed.collectionView.backgroundColor = Styles.Colors.menuBackgroundColor.color
+        feed.collectionView.indicatorStyle = .white
         feed.setLoadingSpinnerColor(to: .white)
         dataSource = self
     }

--- a/Classes/Notifications/Filter/InboxFilterReposViewController.swift
+++ b/Classes/Notifications/Filter/InboxFilterReposViewController.swift
@@ -23,6 +23,7 @@ BaseListViewControllerDataSource {
         title = NSLocalizedString("Watched Repos", comment: "")
         preferredContentSize = Styles.Sizes.contextMenuSize
         feed.collectionView.backgroundColor = Styles.Colors.menuBackgroundColor.color
+        feed.collectionView.indicatorStyle = .white
         feed.setLoadingSpinnerColor(to: .white)
     }
 

--- a/Classes/People/PeopleViewController.swift
+++ b/Classes/People/PeopleViewController.swift
@@ -50,6 +50,7 @@ PeopleSectionControllerDelegate {
         self.dataSource = self
 
         feed.collectionView.backgroundColor = Styles.Colors.menuBackgroundColor.color
+        feed.collectionView.indicatorStyle = .white
         feed.setLoadingSpinnerColor(to: .white)
         preferredContentSize = Styles.Sizes.contextMenuSize
         updateTitle()

--- a/Classes/Repository/RepositoryBranches/RepositoryBranchesViewController.swift
+++ b/Classes/Repository/RepositoryBranches/RepositoryBranchesViewController.swift
@@ -37,6 +37,7 @@ RepositoryBranchSectionControllerDelegate {
         title = NSLocalizedString("Branches", comment: "")
         preferredContentSize = Styles.Sizes.contextMenuSize
         feed.collectionView.backgroundColor = Styles.Colors.menuBackgroundColor.color
+        feed.collectionView.indicatorStyle = .white
         feed.setLoadingSpinnerColor(to: .white)
         dataSource = self
     }


### PR DESCRIPTION
More specifically, in Labels, Milestones, People and Branches view controllers.

<details>
<summary>
Before:
</summary>

![Default scroll indicator](https://user-images.githubusercontent.com/1164565/54523951-5b1cdf00-4979-11e9-89a9-a7de2b00702b.jpeg)
</details>

<details>
<summary>
After:
</summary>

![White scroll indicator](https://user-images.githubusercontent.com/1164565/54523857-24df5f80-4979-11e9-85e3-96b4fae9414f.png)
</details>