### PR TITLE
Preserve emojis order when adding

### DIFF
--- a/Classes/Issues/Comments/Reactions/IssueCommentReactionViewModel.swift
+++ b/Classes/Issues/Comments/Reactions/IssueCommentReactionViewModel.swift
@@ -34,11 +34,10 @@ final class IssueCommentReactionViewModel: ListDiffable {
 
     init(models: [ReactionViewModel]) {
         let reactions = IssueCommentReactionViewModel.allReactions
-        let sortedModels = models.sorted { (m1, m2) -> Bool in
-            let m1Idx = reactions.firstIndex(of: m1.content) ?? 0
-            let m2Idx = reactions.firstIndex(of: m2.content) ?? 0
-            return m1Idx < m2Idx
+        let indexOfModel: (ReactionViewModel) -> Int = {
+            reactions.firstIndex(of: $0.content) ?? 0
         }
+        let sortedModels = models.sorted { indexOfModel($0) < indexOfModel($1) }
         self.models = sortedModels
 
         var map = [ReactionContent: ReactionViewModel]()

--- a/Classes/Issues/Comments/Reactions/IssueCommentReactionViewModel.swift
+++ b/Classes/Issues/Comments/Reactions/IssueCommentReactionViewModel.swift
@@ -17,16 +17,33 @@ extension ReactionContent: Hashable {
 
 final class IssueCommentReactionViewModel: ListDiffable {
 
+    static let allReactions: [ReactionContent] = [
+        .thumbsUp,
+        .thumbsDown,
+        .laugh,
+        .hooray,
+        .confused,
+        .heart,
+        .rocket,
+        .eyes
+    ]
+
     let models: [ReactionViewModel]
     private let map: [ReactionContent: ReactionViewModel]
     private let flatState: String
 
     init(models: [ReactionViewModel]) {
-        self.models = models
+        let reactions = IssueCommentReactionViewModel.allReactions
+        let sortedModels = models.sorted { (m1, m2) -> Bool in
+            let m1Idx = reactions.firstIndex(of: m1.content) ?? 0
+            let m2Idx = reactions.firstIndex(of: m2.content) ?? 0
+            return m1Idx < m2Idx
+        }
+        self.models = sortedModels
 
         var map = [ReactionContent: ReactionViewModel]()
         var flatState = ""
-        for model in models {
+        for model in sortedModels {
             map[model.content] = model
             flatState += "\(model.content.rawValue)\(model.count)"
         }

--- a/Classes/Issues/Comments/Reactions/IssueReactionCell.swift
+++ b/Classes/Issues/Comments/Reactions/IssueReactionCell.swift
@@ -89,6 +89,7 @@ final class IssueReactionCell: UICollectionViewCell {
         accessibilityHint = isViewer
             ? NSLocalizedString("Tap to remove your reaction", comment: "")
             : NSLocalizedString("Tap to react with this emoji", comment: "")
+        restoreDisplay()
     }
 
     func popIn() {
@@ -109,9 +110,7 @@ final class IssueReactionCell: UICollectionViewCell {
         // hack to prevent changing to "0"
         countLabel.text = "1"
 
-        countLabel.alpha = 1
-        emojiLabel.transform = .identity
-        emojiLabel.alpha = 1
+        restoreDisplay()
         UIView.animate(withDuration: 0.2, delay: 0, animations: {
             self.countLabel.alpha = 0
             self.emojiLabel.transform = CGAffineTransform(scaleX: 0.3, y: 0.3)
@@ -129,6 +128,12 @@ final class IssueReactionCell: UICollectionViewCell {
     }
 
     // MARK: Private API
+
+    func restoreDisplay() {
+        countLabel.alpha = 1
+        emojiLabel.transform = .identity
+        emojiLabel.alpha = 1
+    }
 
     @objc func showMenu(recognizer: UITapGestureRecognizer) {
         guard recognizer.state == .began,

--- a/Classes/Issues/Comments/Reactions/ReactionsMenuViewController.swift
+++ b/Classes/Issues/Comments/Reactions/ReactionsMenuViewController.swift
@@ -33,26 +33,25 @@ final class EmojiCell: UICollectionViewCell {
 
 }
 
+private extension Array {
+    func split(toNumberOfChunks number: Int) -> [[Element]] {
+        let size = count / number
+        return (0 ..< number).map {
+            let from = $0 * size
+            let to = from + size
+            let isLast = ($0 == number - 1)
+            return Array(self[from ..< (isLast ? count : to)])
+        }
+    }
+}
+
 final class ReactionsMenuViewController: UICollectionViewController,
     UICollectionViewDelegateFlowLayout {
 
     private let reuseIdentifier = "cell"
     private let size: CGFloat = 50
 
-    private let sectionedReactions: [[ReactionContent]] = [
-        [
-            .thumbsUp,
-            .thumbsDown,
-            .laugh,
-            .hooray
-        ],
-        [
-            .confused,
-            .heart,
-            .rocket,
-            .eyes
-        ]
-    ]
+    private let sectionedReactions = IssueCommentReactionViewModel.allReactions.split(toNumberOfChunks: 2)
 
     var selectedReaction: ReactionContent? {
         guard let item = collectionView?.indexPathsForSelectedItems?.first else { return nil }


### PR DESCRIPTION
* reactions order in app is defined by array in app (not received order from API)
* reactions picker & UI list share the same data structure

Closes #2403.

When inserting reaction to the middle last cell held UI state applied by `pullOut` and that's why that had to be extracted to a separate method which has to be called by `configure` method.

Not sure if private `Array` extension is correct [implementation](https://github.com/GitHawkApp/GitHawk/pull/2698/files#diff-37a418fe95a2aab45fe0f263b55a58c0R36) in this case.