### PR TITLE
add hit test to capture touch and send to subviews on notification cell

### DIFF
--- a/Classes/Notifications/NotificationCell.swift
+++ b/Classes/Notifications/NotificationCell.swift
@@ -153,6 +153,17 @@ final class NotificationCell: SelectableCell, CAAnimationDelegate {
     override var canBecomeFirstResponder: Bool {
         return true
     }
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        for view in subviews {
+            let newPoint = view.convert(point, from: self)
+            let view = view.hitTest(newPoint, with: event)
+            if view != nil {
+                return view
+            }
+        }
+        return super.hitTest(point, with: event)
+    }
 
     public func configure(with model: NotificationViewModel, delegate: NotificationCellDelegate?) {
         textView.configure(with: model.title, width: contentView.bounds.width)


### PR DESCRIPTION
- Add a hitTest on notification cell and propagating touches to subviews.

Closes #2657 