### PR TITLE
Fix Bundler conflict in Bitrise

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,4 +73,4 @@ DEPENDENCIES
   cocoapods
 
 BUNDLED WITH
-   2.0.1
+   1.16.6


### PR DESCRIPTION
Took forever to figure this out. Bitrise has been broken since 2/22. This commit broke it by updating Bundler to a version that conflicts w/ the fastlane/deploy Bitrise step.

https://github.com/GitHawkApp/GitHawk/commit/f0a62aa7d28a61bf8e15b741052067dd3fff83ee#diff-e79a60dc6b85309ae70a6ea8261eaf95

Testing deploying TF build from this PR.