### PR TITLE
Update README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ GitHawk is the highest rated iOS app for GitHub.
 
 ## Contributing
 
-We are always looking for contributions from **all skill levels**! A great way to get started is by helping [organize and/or squish bugs](https://github.com/GitHawkApp/GitHawk/issues?q=is%3Aissue+is%3Aopen+label%3A%22%3Abug%3A+bug%22). If you're looking to ease your way into the project try out a [good first issue](https://github.com/GitHawkApp/GitHawk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+We are always looking for contributions from **all skill levels**! A great way to get started is by helping [organize and/or squish bugs](https://github.com/GitHawkApp/GitHawk/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3A%22🐛+bug%22). If you're looking to ease your way into the project try out a [good first issue](https://github.com/GitHawkApp/GitHawk/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3A%22✨+good+first+issue%22+).
 
 #### Highest Priority Needs:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We are always looking for contributions from **all skill levels**! A great way t
 #### Highest Priority Needs:
 
 - 👩‍💼 **Product Manager**
-  - We have some [projects](https://github.com/GitHawkApp/GitHawk/projects) and tons of unorganized/unprioritized [features](https://github.com/GitHawkApp/GitHawk/issues?q=is%3Aissue+is%3Aopen+label%3Afeature-request). GitHawk needs someone to own the product direction!
+  - We have some [projects](https://github.com/GitHawkApp/GitHawk/projects) and tons of unorganized/unprioritized [features](https://github.com/GitHawkApp/GitHawk/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3A%22🆕+feature+request%22+). GitHawk needs someone to own the product direction!
 - 👩‍🎨 **Designer**
   - Like making unique UIs? So do we! We value keeping GitHawk's UX close to core iOS, but, when necessary, create our own high-quality UI components. Helping design for GitHawk is a great opportunity to try new ideas out!
 - 👩‍💻 **iOS Project Management**


### PR DESCRIPTION
Reading through readme, I noticed that some links became outdated as new labels were introduced:

I updated:

1. (open bugs) https://github.com/GitHawkApp/GitHawk/issues?q=is%3Aissue+is%3Aopen+label%3A%22%3Abug%3A+bug%22 ➡️ https://github.com/GitHawkApp/GitHawk/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3A%22🐛+bug%22
2. (open good first issues) https://github.com/GitHawkApp/GitHawk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22 ➡️ https://github.com/GitHawkApp/GitHawk/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3A%22✨+good+first+issue%22+
3. (open feature requests) https://github.com/GitHawkApp/GitHawk/issues?q=is%3Aissue+is%3Aopen+label%3Afeature-request ➡️ https://github.com/GitHawkApp/GitHawk/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3A%22🆕+feature+request%22+