### PR TITLE
Fix extra space at the bottom of pull request status view (#2229)

### DIFF
--- a/Classes/Issues/IssueManagingContextController.swift
+++ b/Classes/Issues/IssueManagingContextController.swift
@@ -12,6 +12,7 @@ import GitHubAPI
 
 protocol IssueManagingContextControllerDelegate: class {
     func willMutateModel(from controller: IssueManagingContextController)
+    func didUpdateManageButtonVisibility(_ manageButton: UIView)
 }
 
 final class IssueManagingContextController: NSObject, ContextMenuDelegate {
@@ -80,6 +81,7 @@ final class IssueManagingContextController: NSObject, ContextMenuDelegate {
 
     func updateButtonVisibility() {
         manageButton.isHidden = actions.count == 0
+        delegate?.didUpdateManageButtonVisibility(manageButton)
     }
 
     enum Action {

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -644,4 +644,8 @@ IssueManagingContextControllerDelegate {
         needsScrollToBottom = true
     }
 
+    func didUpdateManageButtonVisibility(_ manageButton: UIView) {
+        feed.collectionView.updateSafeInset(container: view, base: threadInset)
+    }
+
 }

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -51,6 +51,9 @@ IssueManagingContextControllerDelegate {
         bottom: 2 * Styles.Sizes.rowSpacing + Styles.Sizes.tableCellHeight,
         right: Styles.Sizes.gutter
     )
+    private var insetForManageButton: CGFloat {
+        return manageController.manageButton.isHidden ? 0 : manageController.manageButton.frame.height
+    }
 
     private var needsScrollToBottom = false
     private var lastTimelineElement: ListDiffable?

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -45,14 +45,16 @@ IssueManagingContextControllerDelegate {
     private var bookmarkNavController: BookmarkNavigationController?
     private var autocompleteController: AutocompleteController!
     private let manageController: IssueManagingContextController
-    private let threadInset = UIEdgeInsets(
-        top: Styles.Sizes.rowSpacing / 2,
-        left: Styles.Sizes.gutter,
-        bottom: 2 * Styles.Sizes.rowSpacing + Styles.Sizes.tableCellHeight,
-        right: Styles.Sizes.gutter
-    )
     private var insetForManageButton: CGFloat {
         return manageController.manageButton.isHidden ? 0 : manageController.manageButton.frame.height
+    }
+    private var threadInset: UIEdgeInsets {
+        return UIEdgeInsets(
+            top: Styles.Sizes.rowSpacing / 2,
+            left: Styles.Sizes.gutter,
+            bottom: 2 * Styles.Sizes.rowSpacing + insetForManageButton,
+            right: Styles.Sizes.gutter
+        )
     }
 
     private var needsScrollToBottom = false


### PR DESCRIPTION
This is a fix for https://github.com/GitHawkApp/GitHawk/issues/2229.

It builds on work and code review comments in https://github.com/GitHawkApp/GitHawk/pull/2294. `IssueManagingContextControllerDelegate` is notified of changes to the button's visibility so that it can update its layout (in this case, update collection view's inset) - I was hoping this would make the update more explicit. The inset itself is calculated using the button's `height` instead of relying on `Styles.Sizes.tableCellHeight`.

Let me know if any of this is not clear or could be improved. I'm happy to try the other approaches suggested in the old pull request - a) moving the button hiding out into the VC, b) giving the manage controller a reference to the scroll view or c) putting a transparent view with the appropriate height at the bottom of the scroll view.

![Before and after](https://user-images.githubusercontent.com/9299317/58387607-42ffb680-7fdf-11e9-9eb7-780fa36993b9.png)

🚀