### PR TITLE
Fix logout crash

### DIFF
--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -212,7 +212,10 @@ GitHubSessionListener {
                 self?.signout()
             }
         ])
-
+        if let popoverPresentationController = alert.popoverPresentationController {
+            popoverPresentationController.sourceView = signOutCell
+            popoverPresentationController.sourceRect = signOutCell.bounds
+        }
         present(alert, animated: trueUnlessReduceMotionEnabled)
     }
 


### PR DESCRIPTION
This is a fix for https://github.com/GitHawkApp/GitHawk/issues/2743 and https://github.com/GitHawkApp/GitHawk/issues/2643.

Reading through the issues, It looks like the crash only occurred on iPads and that's where I was able to reproduce it. It's the notorious `popoverPresentationController` that's always too easy to miss. 🧐