### PR TITLE
Fix pushing Issues VC when user taps on username in referenced issues

### DIFF
--- a/Classes/Issues/Referenced/IssueReferencedModel.swift
+++ b/Classes/Issues/Referenced/IssueReferencedModel.swift
@@ -53,12 +53,6 @@ final class IssueReferencedModel: ListDiffable {
         self.title = title
         self.actor = actor
 
-        let issueDetailsModel = IssueDetailsModel(
-        owner: actor,
-        repo: repo,
-        number: number
-        )
-
         let builder = StyledTextBuilder(styledText: StyledText(
             style: Styles.Text.secondary.with(foreground: Styles.Colors.Gray.medium.color)
         ))
@@ -75,9 +69,9 @@ final class IssueReferencedModel: ListDiffable {
             .restore()
             .add(text: "\n")
             .save()
-            .add(styledText: StyledText(text: title, style: Styles.Text.secondaryBold.with(attributes: [MarkdownAttribute.issue: issueDetailsModel]) ))
+            .add(styledText: StyledText(text: title, style: Styles.Text.secondaryBold))
             .restore()
-            .add(text: " #\(number)", attributes: [MarkdownAttribute.issue: issueDetailsModel])
+            .add(text: " #\(number)")
 
         self.string = StyledTextRenderer(
             string: builder.build(),

--- a/Classes/Issues/Referenced/IssueReferencedModel.swift
+++ b/Classes/Issues/Referenced/IssueReferencedModel.swift
@@ -53,6 +53,12 @@ final class IssueReferencedModel: ListDiffable {
         self.title = title
         self.actor = actor
 
+        let issueDetailsModel = IssueDetailsModel(
+        owner: actor,
+        repo: repo,
+        number: number
+        )
+
         let builder = StyledTextBuilder(styledText: StyledText(
             style: Styles.Text.secondary.with(foreground: Styles.Colors.Gray.medium.color)
         ))
@@ -69,9 +75,9 @@ final class IssueReferencedModel: ListDiffable {
             .restore()
             .add(text: "\n")
             .save()
-            .add(styledText: StyledText(text: title, style: Styles.Text.secondaryBold))
+            .add(styledText: StyledText(text: title, style: Styles.Text.secondaryBold.with(attributes: [MarkdownAttribute.issue: issueDetailsModel]) ))
             .restore()
-            .add(text: " #\(number)")
+            .add(text: " #\(number)", attributes: [MarkdownAttribute.issue: issueDetailsModel])
 
         self.string = StyledTextRenderer(
             string: builder.build(),

--- a/Classes/Issues/Referenced/IssueReferencedSectionController.swift
+++ b/Classes/Issues/Referenced/IssueReferencedSectionController.swift
@@ -48,11 +48,11 @@ final class IssueReferencedSectionController: ListGenericSectionController<Issue
     // MARK: MarkdownStyledTextViewDelegate
 
     func didTap(cell: MarkdownStyledTextView, attribute: DetectedMarkdownAttribute) {
-        switch attribute {
-        case .username(let username):
+        if case let .username(username) = attribute {
             shouldShowIssueOnItemSelection = false
             viewController?.presentProfile(login: username)
-        default: viewController?.didTap(cell: cell, attribute: attribute)
+        } else {
+            viewController?.didTap(cell: cell, attribute: attribute)
         }
     }
 

--- a/Classes/Issues/Referenced/IssueReferencedSectionController.swift
+++ b/Classes/Issues/Referenced/IssueReferencedSectionController.swift
@@ -52,9 +52,6 @@ final class IssueReferencedSectionController: ListGenericSectionController<Issue
         case .username(let username):
             shouldShowIssueOnItemSelection = false
             viewController?.presentProfile(login: username)
-        case .issue(let issue):
-            shouldShowIssueOnItemSelection = false
-            viewController?.route_push(to: IssuesViewController(client: client, model: issue))
         default: viewController?.didTap(cell: cell, attribute: attribute)
         }
     }

--- a/Classes/Issues/Referenced/IssueReferencedSectionController.swift
+++ b/Classes/Issues/Referenced/IssueReferencedSectionController.swift
@@ -48,12 +48,10 @@ final class IssueReferencedSectionController: ListGenericSectionController<Issue
     // MARK: MarkdownStyledTextViewDelegate
 
     func didTap(cell: MarkdownStyledTextView, attribute: DetectedMarkdownAttribute) {
-        if case let .username(username) = attribute {
-            shouldShowIssueOnItemSelection = false
-            viewController?.presentProfile(login: username)
-        } else {
-            viewController?.didTap(cell: cell, attribute: attribute)
+        guard let viewController = viewController else {
+            return
         }
+        shouldShowIssueOnItemSelection = !viewController.handle(attribute: attribute)
     }
 
 }


### PR DESCRIPTION
This fixes #2260. 🤞 

When user taps `IssueReferencedCell`, 2 competing delegates can be notified - 

1. `UICollectionViewDelegate`
2. `MarkdownStyledTextViewDelegate`

When both delegates are notified (for example when user taps username in a referenced issue), `UICollectionViewDelegate` (`IssueReferencedSectionController`) will push a new `IssuesViewController` :

https://github.com/GitHawkApp/GitHawk/blob/f28b119009e96a1a6dd53ae0e90b7beefc58833c/Classes/Issues/Referenced/IssueReferencedSectionController.swift#L39

and `MarkdownStyledTextViewDelegate` (`IssuesViewController`) will present a profile via `SFSafariViewController` :

https://github.com/GitHawkApp/GitHawk/blob/80d1255401f9d5b53472dd34a3543d3acdf6da1c/Classes/Utility/UIViewController%2BRouting.swift#L21

Since `IssueReferencedSectionController` implements `UICollectionViewDelegate`, I made it conform to the competing delegate (`MarkdownStyledTextViewDelegate`) so that we can figure out which delegate should proceed - if we're notified that username was tapped, we'll present the profile VC and set a flag that will prevent the other delegate from pushing the Issues VC.

Let me know if there's a better way to do this. 🤔 