### PR TITLE
update brew install command

### DIFF
--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -22,7 +22,7 @@ xcode-select --install
 <td width="33%" align="center">macOS or Linux with Ruby 2.0.0 or above</td>
 </tr>
 <tr>
-<td width="33%"><code>brew cask install fastlane</code></td>
+<td width="33%"><code>brew install --cask fastlane</code></td>
 <td width="33%"><a href="https://download.fastlane.tools">Download the zip file</a>. Then double click on the <code>install</code> script (or run it in a terminal window).</td>
 <td width="33%"><code>sudo gem install fastlane -NV</code></td>
 </tr>


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524